### PR TITLE
Fix #7: Asserter Can Give Details For Fakes

### DIFF
--- a/docs/pages/Tools-Asserter.md
+++ b/docs/pages/Tools-Asserter.md
@@ -2,6 +2,7 @@
 
 The `Asserter` tool provides methods to verify common test scenarios:
 
+* `CheckAll` - Verifies multiple cases and aggregates failure.
 * `Throws` - Verifies an exception is thrown.
 * `IsEmpty` - Verifies a collection has no elements.
 * `IsNotEmpty` - Verifies a collection has elements.

--- a/docs/pages/Tools-Faker.md
+++ b/docs/pages/Tools-Faker.md
@@ -27,7 +27,7 @@ public void Setup_ObjectEquality()
     Tools.Asserter.Is(false, fake.Dummy.Equals(new object()));
     Tools.Asserter.Is(true, fake.Dummy.Equals(data));
 
-    fake.Verify(Times.Exactly(2));
+    fake.VerifyAll(Times.Exactly(2));
 }
 ```
 
@@ -45,8 +45,8 @@ The `Faker` requires a `Valuer` to be given at creation, which controls value eq
 
 There are a variety of options to verify methods were called as expected:
 
-* `Fake.Verify()` - Automatically checks methods based upon `Times` in each Behavior.
-* `Fake.Verify(Times)` - Does the above and that the total matches the provided `Times`.
+* `Fake.VerifyAll()` - Automatically checks methods based upon `Times` in each Behavior.
+* `Fake.VerifyAll(Times)` - Does the above and that the total matches the provided `Times`.
 * `Fake.Verify(Times, delegate)` - Verifies the given delegate was called the given `Times`.
 * `Fake.VerifyTotalCalls(Times)` - Only verifies the total number of calls made.
 

--- a/src/CreateAndFake/CreateAndFake.csproj
+++ b/src/CreateAndFake/CreateAndFake.csproj
@@ -23,7 +23,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.5.0</Version>
+    <Version>1.5.1</Version>
     <Authors>CreateAndFake Contributors</Authors>
     <Description>A C# class library that handles mocking, test data generation, and validation.</Description>
     <PackageLicenseUrl>https://mozilla.org/MPL/2.0/</PackageLicenseUrl>

--- a/src/CreateAndFake/Toolbox/AsserterTool/Asserter.cs
+++ b/src/CreateAndFake/Toolbox/AsserterTool/Asserter.cs
@@ -20,6 +20,34 @@ namespace CreateAndFake.Toolbox.AsserterTool
             Valuer = valuer ?? throw new ArgumentNullException(nameof(valuer));
         }
 
+        /// <summary>Runs each case and aggregates exceptions.</summary>
+        /// <param name="cases">Assert cases.</param>
+        public virtual void CheckAll(params Action[] cases)
+        {
+            if (cases == null) return;
+
+            Exception[] errors = new Exception[cases.Length];
+            for (int i = 0; i < errors.Length; i++)
+            {
+                try
+                {
+                    cases[i].Invoke();
+                    errors[i] = null;
+                }
+                catch (Exception e)
+                {
+                    errors[i] = e;
+                }
+            }
+
+            if (errors.Any(e => e != null))
+            {
+                throw new AggregateException("Cases failed: " +
+                    String.Join(", ", Enumerable.Range(0, errors.Length).Where(i => errors[i] != null)),
+                    errors.Where(e => e != null));
+            }
+        }
+
         /// <summary>Throws an assert exception.</summary>
         /// <param name="details">Optional failure details.</param>
         public virtual void Fail(string details = null)

--- a/src/CreateAndFake/Toolbox/AsserterTool/Asserter.cs
+++ b/src/CreateAndFake/Toolbox/AsserterTool/Asserter.cs
@@ -43,7 +43,7 @@ namespace CreateAndFake.Toolbox.AsserterTool
             if (errors.Any(e => e != null))
             {
                 throw new AggregateException("Cases failed: " +
-                    String.Join(", ", Enumerable.Range(0, errors.Length).Where(i => errors[i] != null)),
+                    String.Join(", ", Enumerable.Range(0, errors.Length).Where(i => errors[i] != null)) + " -",
                     errors.Where(e => e != null));
             }
         }

--- a/src/CreateAndFake/Toolbox/FakerTool/Fake.cs
+++ b/src/CreateAndFake/Toolbox/FakerTool/Fake.cs
@@ -54,9 +54,9 @@ namespace CreateAndFake.Toolbox.FakerTool
             Dummy.FakeMeta.SetCallBehavior(new CallData(methodName, generics, args, Valuer), callback);
         }
 
-        /// <summary>Verifies behavior with associated times were called as expected.</summary>
+        /// <summary>Verifies all behaviors with associated times were called as expected.</summary>
         /// <param name="total">Expected total number of calls to test as well.</param>
-        public void Verify(Times total = null)
+        public void VerifyAll(Times total = null)
         {
             Dummy.FakeMeta.Verify();
             if (total != null)

--- a/tests/CreateAndFakeTests/Design/Content/ValueComparerTests.cs
+++ b/tests/CreateAndFakeTests/Design/Content/ValueComparerTests.cs
@@ -39,24 +39,28 @@ namespace CreateAndFakeTests.Design.Content
             Fake<IValueEquatable> stub1, Fake<IValueEquatable> stub2)
         {
             ValueComparer.Use.Equals(stub1.Dummy, stub2.Dummy);
-            stub1.Verify(1, m => m.ValuesEqual(stub2.Dummy));
-            stub1.VerifyTotalCalls(1);
-            stub2.VerifyTotalCalls(0);
+            Tools.Asserter.CheckAll(
+                () => stub1.Verify(1, m => m.ValuesEqual(stub2.Dummy)),
+                () => stub1.VerifyTotalCalls(1),
+                () => stub2.VerifyTotalCalls(0));
 
             ValueComparer.Use.Equals((object)stub1.Dummy, stub2.Dummy);
-            stub1.Verify(2, m => m.ValuesEqual(stub2.Dummy));
-            stub1.VerifyTotalCalls(2);
-            stub2.VerifyTotalCalls(0);
+            Tools.Asserter.CheckAll(
+                () => stub1.Verify(2, m => m.ValuesEqual(stub2.Dummy)),
+                () => stub1.VerifyTotalCalls(2),
+                () => stub2.VerifyTotalCalls(0));
 
             ValueComparer.Use.Compare(stub1.Dummy, stub2.Dummy);
-            stub1.Verify(1, m => m.GetValueHash());
-            stub1.VerifyTotalCalls(3);
-            stub2.Verify(1, m => m.GetValueHash());
-            stub2.VerifyTotalCalls(1);
+            Tools.Asserter.CheckAll(
+                () => stub1.Verify(1, m => m.GetValueHash()),
+                () => stub1.VerifyTotalCalls(3),
+                () => stub2.Verify(1, m => m.GetValueHash()),
+                () => stub2.VerifyTotalCalls(1));
 
             ValueComparer.Use.GetHashCode((object)stub1.Dummy);
-            stub1.Verify(2, m => m.GetValueHash());
-            stub1.VerifyTotalCalls(4);
+            Tools.Asserter.CheckAll(
+                () => stub1.Verify(2, m => m.GetValueHash()),
+                () => stub1.VerifyTotalCalls(4));
         }
 
         /// <summary>Verifies the type works as intended.</summary>

--- a/tests/CreateAndFakeTests/Toolbox/AsserterTool/AsserterTests.cs
+++ b/tests/CreateAndFakeTests/Toolbox/AsserterTool/AsserterTests.cs
@@ -183,7 +183,7 @@ namespace CreateAndFakeTests.Toolbox.AsserterTool
             Tools.Asserter.Throws<AssertException>(
                 () => m_TestInstance.Throws<Exception>(() => disposable.Dummy));
 
-            disposable.Verify(Times.Once);
+            disposable.VerifyAll(Times.Once);
         }
 
         /// <summary>Verifies aggregate exception wrapping is ignored.</summary>
@@ -283,7 +283,7 @@ namespace CreateAndFakeTests.Toolbox.AsserterTool
             Tools.Asserter.Throws<AssertException>(
                 () => m_TestInstance.ReferenceEqual(fake.Dummy, Tools.Duplicator.Copy(fake.Dummy)));
 
-            fake.Verify(Times.Never);
+            fake.VerifyAll(Times.Never);
         }
 
         /// <summary>Verifies equality comparison is not used.</summary>
@@ -298,7 +298,7 @@ namespace CreateAndFakeTests.Toolbox.AsserterTool
             Tools.Asserter.Throws<AssertException>(
                 () => m_TestInstance.ReferenceNotEqual(fake.Dummy, fake.Dummy));
 
-            fake.Verify(Times.Never);
+            fake.VerifyAll(Times.Never);
         }
 
         /// <summary>Verifies valid when no differences are found.</summary>
@@ -311,7 +311,7 @@ namespace CreateAndFakeTests.Toolbox.AsserterTool
 
             m_TestInstance.ValuesEqual(new object(), new object());
 
-            m_FakeValuer.Verify(Times.Once);
+            m_FakeValuer.VerifyAll(Times.Once);
         }
 
         /// <summary>Verifies invalid when differences are found.</summary>
@@ -330,7 +330,7 @@ namespace CreateAndFakeTests.Toolbox.AsserterTool
             Tools.Asserter.Throws<AssertException>(
                 () => m_TestInstance.ValuesEqual(null, new object()));
 
-            m_FakeValuer.Verify(Times.Exactly(2));
+            m_FakeValuer.VerifyAll(Times.Exactly(2));
         }
 
         /// <summary>Verifies invalid when no differences are found.</summary>
@@ -349,7 +349,7 @@ namespace CreateAndFakeTests.Toolbox.AsserterTool
             Tools.Asserter.Throws<AssertException>(
                 () => m_TestInstance.ValuesNotEqual(null, new object()));
 
-            m_FakeValuer.Verify(Times.Exactly(2));
+            m_FakeValuer.VerifyAll(Times.Exactly(2));
         }
 
         /// <summary>Verifies invalid when differences are found.</summary>
@@ -362,7 +362,7 @@ namespace CreateAndFakeTests.Toolbox.AsserterTool
 
             m_TestInstance.ValuesNotEqual(new object(), new object());
 
-            m_FakeValuer.Verify(Times.Once);
+            m_FakeValuer.VerifyAll(Times.Once);
         }
     }
 }

--- a/tests/CreateAndFakeTests/Toolbox/AsserterTool/AsserterTests.cs
+++ b/tests/CreateAndFakeTests/Toolbox/AsserterTool/AsserterTests.cs
@@ -51,6 +51,48 @@ namespace CreateAndFakeTests.Toolbox.AsserterTool
             Tools.Tester.PreventsParameterMutation<Asserter>();
         }
 
+        /// <summary>Verifies each case is run.</summary>
+        [Fact]
+        public void CheckAll_ValidRunsAll()
+        {
+            bool ran1 = false;
+            bool ran2 = false;
+
+            m_TestInstance.CheckAll(
+                () => ran1 = true,
+                () => ran2 = true);
+
+            Tools.Asserter.Is(true, ran1);
+            Tools.Asserter.Is(true, ran2);
+        }
+
+        /// <summary>Verifies only one error is thrown.</summary>
+        [Theory, RandomData]
+        public void CheckAll_SingleErrorThrows(Exception error)
+        {
+            bool ran2 = false;
+
+            AggregateException result = Tools.Asserter.Throws<AggregateException>(
+                () => m_TestInstance.CheckAll(
+                    () => throw error,
+                    () => ran2 = true));
+
+            Tools.Asserter.Is(true, ran2);
+            Tools.Asserter.Is(result.InnerExceptions.ToArray(), new[] { error });
+        }
+
+        /// <summary>Verifies each case is run.</summary>
+        [Theory, RandomData]
+        public void CheckAll_ErrorRunsAll(Exception error1, Exception error2)
+        {
+            AggregateException result = Tools.Asserter.Throws<AggregateException>(
+                () => m_TestInstance.CheckAll(
+                    () => throw error1,
+                    () => throw error2));
+
+            Tools.Asserter.Is(result.InnerExceptions.ToArray(), new[] { error1, error2 });
+        }
+
         /// <summary>Verifies fail will throw.</summary>
         [Fact]
         public static void Fail_Throws()

--- a/tests/CreateAndFakeTests/Toolbox/DuplicatorTool/DuplicatorTests.cs
+++ b/tests/CreateAndFakeTests/Toolbox/DuplicatorTool/DuplicatorTests.cs
@@ -54,8 +54,11 @@ namespace CreateAndFakeTests.Toolbox.DuplicatorTool
                 m => m.TryCopy(data, Arg.Any<DuplicatorChainer>()),
                 Behavior.Returns((true, data), Times.Once));
 
-            Tools.Asserter.Is(data, new Duplicator(Tools.Asserter, false, hint.Dummy).Copy(data));
-            hint.Verify(Times.Once);
+            object result = new Duplicator(Tools.Asserter, false, hint.Dummy).Copy(data);
+
+            Tools.Asserter.CheckAll(
+                () => Tools.Asserter.Is(data, result),
+                () => hint.Verify(Times.Once));
         }
 
         /// <summary>Verifies an infinite loop exception is caught and given details.</summary>

--- a/tests/CreateAndFakeTests/Toolbox/DuplicatorTool/DuplicatorTests.cs
+++ b/tests/CreateAndFakeTests/Toolbox/DuplicatorTool/DuplicatorTests.cs
@@ -58,7 +58,7 @@ namespace CreateAndFakeTests.Toolbox.DuplicatorTool
 
             Tools.Asserter.CheckAll(
                 () => Tools.Asserter.Is(data, result),
-                () => hint.Verify(Times.Once));
+                () => hint.VerifyAll(Times.Once));
         }
 
         /// <summary>Verifies an infinite loop exception is caught and given details.</summary>

--- a/tests/CreateAndFakeTests/Toolbox/FakerTool/FakeTests.cs
+++ b/tests/CreateAndFakeTests/Toolbox/FakerTool/FakeTests.cs
@@ -14,7 +14,7 @@ namespace CreateAndFakeTests.Toolbox.FakerTool
         [Fact]
         public static void Verify_NoTotalValid()
         {
-            Tools.Faker.Mock<object>().Verify();
+            Tools.Faker.Mock<object>().VerifyAll();
         }
 
         /// <summary>Verifies protected methods are supported.</summary>

--- a/tests/CreateAndFakeTests/Toolbox/FakerTool/Fake[T]Tests.cs
+++ b/tests/CreateAndFakeTests/Toolbox/FakerTool/Fake[T]Tests.cs
@@ -70,7 +70,7 @@ namespace CreateAndFakeTests.Toolbox.FakerTool
             fake.Dummy.ReturnVoid(out string value);
 
             Tools.Asserter.Is(data, value);
-            fake.Verify(Times.Once);
+            fake.VerifyAll(Times.Once);
         }
 
         /// <summary>Verifies faking works with ref arguments.</summary>
@@ -86,7 +86,7 @@ namespace CreateAndFakeTests.Toolbox.FakerTool
             fake.Dummy.ReturnVoid(ref value);
 
             Tools.Asserter.Is(data, value);
-            fake.Verify(Times.Once);
+            fake.VerifyAll(Times.Once);
         }
 
         /// <summary>Verifies faking works with generics.</summary>
@@ -105,7 +105,7 @@ namespace CreateAndFakeTests.Toolbox.FakerTool
             Tools.Asserter.Is(true, fake.Dummy.Run<DataSample, bool>(text, sample));
             Tools.Asserter.Is(5, fake.Dummy.Run<DataSample, int>(text, sample));
 
-            fake.Verify(Times.Exactly(2));
+            fake.VerifyAll(Times.Exactly(2));
 
             Tools.Asserter.Throws<FakeCallException>(
                 () => fake.Dummy.Run<DataSample, object>(text, sample));

--- a/tests/CreateAndFakeTests/Toolbox/RandomizerTool/RandomizerTests.cs
+++ b/tests/CreateAndFakeTests/Toolbox/RandomizerTool/RandomizerTests.cs
@@ -55,7 +55,7 @@ namespace CreateAndFakeTests.Toolbox.RandomizerTool
             Tools.Asserter.Throws<NotSupportedException>(
                 () => new Randomizer(Tools.Faker, new FastRandom(), false, hint.Dummy).Create<string>());
 
-            hint.Verify(Times.Once);
+            hint.VerifyAll(Times.Once);
         }
 
         /// <summary>Verifies hint behavior works.</summary>
@@ -72,7 +72,7 @@ namespace CreateAndFakeTests.Toolbox.RandomizerTool
             Tools.Asserter.Is(data, new Randomizer(Tools.Faker,
                 new FastRandom(), false, hint.Dummy).Create<string>());
 
-            hint.Verify(Times.Once);
+            hint.VerifyAll(Times.Once);
         }
 
         /// <summary>Verifies an infinite loop exception is caught and given details.</summary>

--- a/tests/CreateAndFakeTests/Toolbox/ValuerTool/ValuerTests.cs
+++ b/tests/CreateAndFakeTests/Toolbox/ValuerTool/ValuerTests.cs
@@ -65,7 +65,7 @@ namespace CreateAndFakeTests.Toolbox.ValuerTool
                 Behavior.Returns(result, Times.Once));
 
             Tools.Asserter.Is(result, new Valuer(false, hint.Dummy).GetHashCode(data));
-            hint.Verify(Times.Exactly(2));
+            hint.VerifyAll(Times.Exactly(2));
         }
 
         /// <summary>Verifies an exception throws when no hint matches.</summary>
@@ -99,7 +99,7 @@ namespace CreateAndFakeTests.Toolbox.ValuerTool
 
             Tools.Asserter.Is(true, new Valuer(false, hint.Dummy).Equals(data1, data2));
 
-            hint.Verify(Times.Exactly(2));
+            hint.VerifyAll(Times.Exactly(2));
         }
 
         /// <summary>Verifies differences means unequal.</summary>
@@ -115,7 +115,7 @@ namespace CreateAndFakeTests.Toolbox.ValuerTool
 
             Tools.Asserter.Is(false, new Valuer(false, hint.Dummy).Equals(data1, data2));
 
-            hint.Verify(Times.Exactly(2));
+            hint.VerifyAll(Times.Exactly(2));
         }
 
         /// <summary>Verifies an infinite loop exception is caught and given details.</summary>

--- a/tests/CreateAndFakeTests/ToolsTests.cs
+++ b/tests/CreateAndFakeTests/ToolsTests.cs
@@ -38,7 +38,7 @@ namespace CreateAndFakeTests
             Tools.Asserter.Is(true, faked.Dummy.HasNested(original),
                 "Value equality did not work for args.");
 
-            faked.Verify(Times.Once);
+            faked.VerifyAll(Times.Once);
         }
 
         /// <summary>Verifies the tools have limits.</summary>


### PR DESCRIPTION
<!--- Follow the contributing guide and code of conduct. --->

## Summary
<!--- Describe the code. --->
Asserter now has option to chain asserts and cascade encountered failures. This enables Verify calls to be chained with result assertion and get the failures for both.

## Fulfills
<!--- Specify which issues the contribution solves. --->

* Closes #7: Asserter Can Give Details For Fakes
