### PR TITLE
Fix 56: Add fluent extensions for asserts.

### DIFF
--- a/src/CreateAndFake/Extensions/AssertExtensions.cs
+++ b/src/CreateAndFake/Extensions/AssertExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections;
+using CreateAndFake.Toolbox.AsserterTool.Fluent;
+
+namespace CreateAndFake.Fluent
+{
+    /// <summary>Provides fluent assertions.</summary>
+    public static class AssertExtensions
+    {
+        /// <summary>Handles common test scenarios.</summary>
+        /// <param name="actual">Object to test.</param>
+        /// <returns>Asserter to test with.</returns>
+        public static AssertObject Assert(this object actual)
+        {
+            return new AssertObject(Tools.Valuer, actual);
+        }
+
+        /// <summary>Handles common test scenarios.</summary>
+        /// <param name="collection">Collection to test.</param>
+        /// <returns>Asserter to test with.</returns>
+        public static AssertCollection Assert(this IEnumerable collection)
+        {
+            return new AssertCollection(Tools.Valuer, collection);
+        }
+    }
+}

--- a/src/CreateAndFake/Toolbox/AsserterTool/Asserter.cs
+++ b/src/CreateAndFake/Toolbox/AsserterTool/Asserter.cs
@@ -2,7 +2,7 @@
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Text;
+using CreateAndFake.Toolbox.AsserterTool.Fluent;
 using CreateAndFake.Toolbox.ValuerTool;
 
 namespace CreateAndFake.Toolbox.AsserterTool
@@ -73,7 +73,7 @@ namespace CreateAndFake.Toolbox.AsserterTool
         /// <exception cref="AssertException">If the expected behavior doesn't happen.</exception>
         public void Is(object expected, object actual, string details = null)
         {
-            ValuesEqual(expected, actual, details);
+            new AssertObject(Valuer, actual).Is(expected, details);
         }
 
         /// <summary>Verifies two objects are unequal by value.</summary>
@@ -83,7 +83,7 @@ namespace CreateAndFake.Toolbox.AsserterTool
         /// <exception cref="AssertException">If the expected behavior doesn't happen.</exception>
         public void IsNot(object expected, object actual, string details = null)
         {
-            ValuesNotEqual(expected, actual, details);
+            new AssertObject(Valuer, actual).IsNot(expected, details);
         }
 
         /// <summary>Verifies a collection is empty.</summary>
@@ -92,7 +92,7 @@ namespace CreateAndFake.Toolbox.AsserterTool
         /// <exception cref="AssertException">If the expected behavior doesn't happen.</exception>
         public virtual void IsEmpty(IEnumerable collection, string details = null)
         {
-            HasCount(0, collection, details);
+            new AssertCollection(Valuer, collection).IsEmpty(details);
         }
 
         /// <summary>Verifies a collection is not empty.</summary>
@@ -101,7 +101,7 @@ namespace CreateAndFake.Toolbox.AsserterTool
         /// <exception cref="AssertException">If the expected behavior doesn't happen.</exception>
         public virtual void IsNotEmpty(IEnumerable collection, string details = null)
         {
-            Is(true, collection?.GetEnumerator().MoveNext(), details);
+            new AssertCollection(Valuer, collection).IsNotEmpty(details);
         }
 
         /// <summary>Verifies a collection is of a certain size.</summary>
@@ -111,24 +111,7 @@ namespace CreateAndFake.Toolbox.AsserterTool
         /// <exception cref="AssertException">If the expected behavior doesn't happen.</exception>
         public virtual void HasCount(int count, IEnumerable collection, string details = null)
         {
-            if (collection == null)
-            {
-                throw new AssertException(
-                    $"Expected collection of '{count}' elements, but was 'null'.", details);
-            }
-
-            StringBuilder contents = new StringBuilder();
-            int i = 0;
-            for (IEnumerator data = collection.GetEnumerator(); data.MoveNext(); i++)
-            {
-                contents.Append("[").Append(i).Append("]:").Append(data.Current).AppendLine();
-            }
-
-            if (i != count)
-            {
-                throw new AssertException(
-                    $"Expected collection of '{count}' elements, but was '{i}'.", details, contents.ToString());
-            }
+            new AssertCollection(Valuer, collection).HasCount(count, details);
         }
 
         /// <summary>Verifies two objects are equal by reference.</summary>
@@ -138,10 +121,7 @@ namespace CreateAndFake.Toolbox.AsserterTool
         /// <exception cref="AssertException">If the expected behavior doesn't happen.</exception>
         public virtual void ReferenceEqual(object expected, object actual, string details = null)
         {
-            if (!ReferenceEquals(expected, actual))
-            {
-                throw new AssertException("References failed to equal.", details);
-            }
+            new AssertObject(Valuer, actual).ReferenceEqual(expected, details);
         }
 
         /// <summary>Verifies two objects are not equal by reference.</summary>
@@ -151,10 +131,7 @@ namespace CreateAndFake.Toolbox.AsserterTool
         /// <exception cref="AssertException">If the expected behavior doesn't happen.</exception>
         public virtual void ReferenceNotEqual(object expected, object actual, string details = null)
         {
-            if (ReferenceEquals(expected, actual))
-            {
-                throw new AssertException("References failed to not equal.", details);
-            }
+            new AssertObject(Valuer, actual).ReferenceNotEqual(expected, details);
         }
 
         /// <summary>Verifies two objects are equal by value.</summary>
@@ -164,13 +141,7 @@ namespace CreateAndFake.Toolbox.AsserterTool
         /// <exception cref="AssertException">If the expected behavior doesn't happen.</exception>
         public virtual void ValuesEqual(object expected, object actual, string details = null)
         {
-            Difference[] differences = Valuer.Compare(expected, actual).ToArray();
-            if (differences.Length > 0)
-            {
-                string rootType = (expected ?? actual)?.GetType().Name;
-                throw new AssertException($"Value equality failed for type '{rootType}'.",
-                    details, string.Join<Difference>(Environment.NewLine, differences));
-            }
+            new AssertObject(Valuer, actual).ValuesEqual(expected, details);
         }
 
         /// <summary>Verifies two objects are unequal by value.</summary>
@@ -180,11 +151,7 @@ namespace CreateAndFake.Toolbox.AsserterTool
         /// <exception cref="AssertException">If the expected behavior doesn't happen.</exception>
         public virtual void ValuesNotEqual(object expected, object actual, string details = null)
         {
-            if (!Valuer.Compare(expected, actual).Any())
-            {
-                throw new AssertException(
-                    $"Value inequality failed for type '{expected?.GetType().Name}'.", details, expected?.ToString());
-            }
+            new AssertObject(Valuer, actual).ValuesNotEqual(expected, details);
         }
 
         /// <summary>Verifies the given behavior throws an exception.</summary>

--- a/src/CreateAndFake/Toolbox/AsserterTool/Fluent/AssertChainer.cs
+++ b/src/CreateAndFake/Toolbox/AsserterTool/Fluent/AssertChainer.cs
@@ -1,0 +1,17 @@
+﻿namespace CreateAndFake.Toolbox.AsserterTool.Fluent
+{
+    /// <summary>Allows assertion calls to be chained.</summary>
+    /// <typeparam name="T">Assertion type to chain.</typeparam>
+    public sealed class AssertChainer<T>
+    {
+        /// <summary>Includes another assertion.</summary>
+        public T And { get; }
+
+        /// <summary>Initializer.</summary>
+        /// <param name="chain">Assertion class to chain.</param>
+        public AssertChainer(T chain)
+        {
+            And = chain;
+        }
+    }
+}

--- a/src/CreateAndFake/Toolbox/AsserterTool/Fluent/AssertCollection.cs
+++ b/src/CreateAndFake/Toolbox/AsserterTool/Fluent/AssertCollection.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections;
+using CreateAndFake.Toolbox.ValuerTool;
+
+namespace CreateAndFake.Toolbox.AsserterTool.Fluent
+{
+    /// <summary>Handles assertion calls.</summary>
+    public sealed class AssertCollection : AssertCollectionBase<AssertCollection>
+    {
+        /// <summary>Initializer.</summary>
+        /// <param name="valuer">Handles comparisons.</param>
+        /// <param name="collection">Collection to check.</param>
+        internal AssertCollection(IValuer valuer, IEnumerable collection) : base(valuer, collection) { }
+    }
+}

--- a/src/CreateAndFake/Toolbox/AsserterTool/Fluent/AssertCollectionBase.cs
+++ b/src/CreateAndFake/Toolbox/AsserterTool/Fluent/AssertCollectionBase.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections;
+using System.Text;
+using CreateAndFake.Toolbox.ValuerTool;
+
+namespace CreateAndFake.Toolbox.AsserterTool.Fluent
+{
+    /// <summary>Handles assertion calls.</summary>
+    public abstract class AssertCollectionBase<T> : AssertObjectBase<T> where T : AssertCollectionBase<T>
+    {
+        /// <summary>Collection to check.</summary>
+        protected IEnumerable Collection { get; }
+
+        /// <summary>Initializer.</summary>
+        /// <param name="valuer">Handles comparisons.</param>
+        /// <param name="collection">Collection to check.</param>
+        protected AssertCollectionBase(IValuer valuer, IEnumerable collection) : base(valuer, collection)
+        {
+            Collection = collection;
+        }
+
+        /// <summary>Verifies a collection is empty.</summary>
+        /// <param name="details">Optional failure details.</param>
+        /// <exception cref="AssertException">If the expected behavior doesn't happen.</exception>
+        /// <returns>Chainer to make additional assertions with.</returns>
+        public AssertChainer<T> IsEmpty(string details = null)
+        {
+            return HasCount(0, details);
+        }
+
+        /// <summary>Verifies a collection is not empty.</summary>
+        /// <param name="details">Optional failure details.</param>
+        /// <exception cref="AssertException">If the expected behavior doesn't happen.</exception>
+        /// <returns>Chainer to make additional assertions with.</returns>
+        public AssertChainer<T> IsNotEmpty(string details = null)
+        {
+            new AssertObject(Valuer, Collection?.GetEnumerator().MoveNext()).Is(true, details);
+            return ToChainer();
+        }
+
+        /// <summary>Verifies a collection is of a certain size.</summary>
+        /// <param name="count">Size to check for.</param>
+        /// <param name="details">Optional failure details.</param>
+        /// <exception cref="AssertException">If the expected behavior doesn't happen.</exception>
+        /// <returns>Chainer to make additional assertions with.</returns>
+        public AssertChainer<T> HasCount(int count, string details = null)
+        {
+            if (Collection == null)
+            {
+                throw new AssertException(
+                    $"Expected collection of '{count}' elements, but was 'null'.", details);
+            }
+
+            StringBuilder contents = new StringBuilder();
+            int i = 0;
+            for (IEnumerator data = Collection.GetEnumerator(); data.MoveNext(); i++)
+            {
+                contents.Append("[").Append(i).Append("]:").Append(data.Current).AppendLine();
+            }
+
+            if (i != count)
+            {
+                throw new AssertException(
+                    $"Expected collection of '{count}' elements, but was '{i}'.", details, contents.ToString());
+            }
+
+            return ToChainer();
+        }
+    }
+}

--- a/src/CreateAndFake/Toolbox/AsserterTool/Fluent/AssertObject.cs
+++ b/src/CreateAndFake/Toolbox/AsserterTool/Fluent/AssertObject.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using CreateAndFake.Toolbox.ValuerTool;
+
+namespace CreateAndFake.Toolbox.AsserterTool.Fluent
+{
+    /// <summary>Handles assertion calls.</summary>
+    public sealed class AssertObject : AssertObjectBase<AssertObject>
+    {
+        /// <summary>Sets up the asserter capabilities.</summary>
+        /// <param name="valuer">Handles comparisons.</param>
+        /// <param name="actual">Object to compare with.</param>
+        /// <exception cref="ArgumentNullException">If given a null valuer.</exception>
+        internal AssertObject(IValuer valuer, object actual) : base(valuer, actual) { }
+    }
+}

--- a/src/CreateAndFake/Toolbox/AsserterTool/Fluent/AssertObjectBase.cs
+++ b/src/CreateAndFake/Toolbox/AsserterTool/Fluent/AssertObjectBase.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Linq;
+using CreateAndFake.Toolbox.ValuerTool;
+
+namespace CreateAndFake.Toolbox.AsserterTool.Fluent
+{
+    /// <summary>Handles assertion calls.</summary>
+    public abstract class AssertObjectBase<T> where T : AssertObjectBase<T>
+    {
+        /// <summary>Handles comparisons.</summary>
+        protected IValuer Valuer { get; }
+
+        /// <summary>Object to compare with.</summary>
+        protected object Actual { get; }
+
+        /// <summary>Sets up the asserter capabilities.</summary>
+        /// <param name="valuer">Handles comparisons.</param>
+        /// <param name="actual">Object to compare with.</param>
+        /// <exception cref="ArgumentNullException">If given a null valuer.</exception>
+        protected AssertObjectBase(IValuer valuer, object actual)
+        {
+            Valuer = valuer ?? throw new ArgumentNullException(nameof(valuer));
+
+            Actual = actual;
+        }
+
+        /// <summary>Verifies two objects are equal by value.</summary>
+        /// <param name="expected">Object to compare against.</param>
+        /// <param name="details">Optional failure details.</param>
+        /// <exception cref="AssertException">If the expected behavior doesn't happen.</exception>
+        /// <returns>Chainer to make additional assertions with.</returns>
+        public AssertChainer<T> Is(object expected, string details = null)
+        {
+            return ValuesEqual(expected, details);
+        }
+
+        /// <summary>Verifies two objects are unequal by value.</summary>
+        /// <param name="expected">Object to compare against.</param>
+        /// <param name="details">Optional failure details.</param>
+        /// <exception cref="AssertException">If the expected behavior doesn't happen.</exception>
+        /// <returns>Chainer to make additional assertions with.</returns>
+        public AssertChainer<T> IsNot(object expected, string details = null)
+        {
+            return ValuesNotEqual(expected, details);
+        }
+
+        /// <summary>Verifies two objects are equal by reference.</summary>
+        /// <param name="expected">Object to compare against.</param>
+        /// <param name="details">Optional failure details.</param>
+        /// <exception cref="AssertException">If the expected behavior doesn't happen.</exception>
+        /// <returns>Chainer to make additional assertions with.</returns>
+        public virtual AssertChainer<T> ReferenceEqual(object expected, string details = null)
+        {
+            if (!ReferenceEquals(expected, Actual))
+            {
+                throw new AssertException("References failed to equal.", details);
+            }
+            return ToChainer();
+        }
+
+        /// <summary>Verifies two objects are not equal by reference.</summary>
+        /// <param name="expected">Object to compare against.</param>
+        /// <param name="details">Optional failure details.</param>
+        /// <exception cref="AssertException">If the expected behavior doesn't happen.</exception>
+        /// <returns>Chainer to make additional assertions with.</returns>
+        public virtual AssertChainer<T> ReferenceNotEqual(object expected, string details = null)
+        {
+            if (ReferenceEquals(expected, Actual))
+            {
+                throw new AssertException("References failed to not equal.", details);
+            }
+            return ToChainer();
+        }
+
+        /// <summary>Verifies two objects are equal by value.</summary>
+        /// <param name="expected">Object to compare against.</param>
+        /// <param name="details">Optional failure details.</param>
+        /// <exception cref="AssertException">If the expected behavior doesn't happen.</exception>
+        /// <returns>Chainer to make additional assertions with.</returns>
+        public virtual AssertChainer<T> ValuesEqual(object expected, string details = null)
+        {
+            Difference[] differences = Valuer.Compare(expected, Actual).ToArray();
+            if (differences.Length > 0)
+            {
+                throw new AssertException($"Value equality failed for type '{GetTypeName(expected)}'.",
+                    details, string.Join<Difference>(Environment.NewLine, differences));
+            }
+            return ToChainer();
+        }
+
+        /// <summary>Verifies two objects are unequal by value.</summary>
+        /// <param name="expected">Object to compare against.</param>
+        /// <param name="details">Optional failure details.</param>
+        /// <exception cref="AssertException">If the expected behavior doesn't happen.</exception>
+        /// <returns>Chainer to make additional assertions with.</returns>
+        public virtual AssertChainer<T> ValuesNotEqual(object expected, string details = null)
+        {
+            if (!Valuer.Compare(expected, Actual).Any())
+            {
+                throw new AssertException(
+                    $"Value inequality failed for type '{GetTypeName(expected)}'.", details, expected?.ToString());
+            }
+            return ToChainer();
+        }
+
+        /// <summary>Find a type name to use for messages.</summary>
+        /// <param name="expected">Object to compare against.</param>
+        /// <returns>Found name to use.</returns>
+        protected string GetTypeName(object expected)
+        {
+            return (expected ?? Actual)?.GetType().Name;
+        }
+
+        /// <summary>Converts the instance to a chainer.</summary>
+        /// <returns>The created chainer.</returns>
+        protected AssertChainer<T> ToChainer()
+        {
+            return new AssertChainer<T>((T)this);
+        }
+    }
+}

--- a/tests/CreateAndFakeTests/ExtensionsTests/AssertExtensionsTests.cs
+++ b/tests/CreateAndFakeTests/ExtensionsTests/AssertExtensionsTests.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections;
+using CreateAndFake;
+using CreateAndFake.Fluent;
+using Xunit;
+
+namespace CreateAndFakeTests.ExtensionsTests
+{
+    /// <summary>Verifies behavior.</summary>
+    public static class AssertExtensionsTests
+    {
+        [Fact]
+        internal static void AssertChainer_GuardsNulls()
+        {
+            Tools.Tester.PreventsNullRefException(typeof(AssertExtensions));
+        }
+
+        [Fact]
+        internal static void AssertChainer_NoParameterMutation()
+        {
+            Tools.Tester.PreventsParameterMutation(typeof(AssertExtensions));
+        }
+
+        [Theory, RandomData]
+        internal static void Assert_ObjectIsFluent(int data)
+        {
+            data.Assert().Is(data).And.IsNot(null);
+        }
+
+        [Theory, RandomData]
+        internal static void Assert_StringIsFluent(string data)
+        {
+            data.Assert().Is(data).And.IsNotEmpty().And.HasCount(data.Length);
+        }
+
+        [Theory, RandomData]
+        internal static void Assert_CollectionIsFluent(IEnumerable data)
+        {
+            data.Assert().IsNotEmpty().And.IsNot(null);
+        }
+    }
+}

--- a/tests/CreateAndFakeTests/TestBases/CompareHintTestBase.cs
+++ b/tests/CreateAndFakeTests/TestBases/CompareHintTestBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using CreateAndFake;
 using CreateAndFake.Toolbox.ValuerTool;
 using Xunit;
@@ -44,14 +45,27 @@ namespace CreateAndFakeTests.TestBases
         {
             foreach (Type type in _validTypes)
             {
-                object data = Tools.Randomizer.Create(type);
+                object data = null;
+                try
+                {
+                    data = Tools.Randomizer.Create(type);
 
-                (bool, IEnumerable<Difference>) result = TestInstance.TryCompare(data, data, CreateChainer());
+                    (bool, IEnumerable<Difference>) result = TestInstance.TryCompare(data, data, CreateChainer());
 
-                Tools.Asserter.Is(true, result.Item1,
-                    $"Hint '{typeof(T).Name}' failed to support '{type.Name}'.");
-                Tools.Asserter.IsEmpty(result.Item2,
-                    $"Hint '{typeof(T).Name}' found differences with same '{type.Name}' of '{data.GetType()}'.");
+                    Tools.Asserter.Is(true, result.Item1,
+                        $"Hint '{typeof(T).Name}' failed to support '{type.Name}'.");
+                    Tools.Asserter.IsEmpty(result.Item2,
+                        $"Hint '{typeof(T).Name}' found differences with same '{type.Name}' of '{data.GetType()}'.");
+                }
+                catch (Exception e)
+                {
+                    ExpandReflectionException(e);
+                    throw;
+                }
+                finally
+                {
+                    (data as IDisposable)?.Dispose();
+                }
             }
         }
 
@@ -61,15 +75,29 @@ namespace CreateAndFakeTests.TestBases
         {
             foreach (Type type in _validTypes)
             {
-                object one = Tools.Randomizer.Create(type);
-                object two = Tools.Mutator.Variant(one.GetType(), one);
+                object one = null, two = null;
+                try
+                {
+                    one = Tools.Randomizer.Create(type);
+                    two = Tools.Mutator.Variant(one.GetType(), one);
 
-                (bool, IEnumerable<Difference>) result = TestInstance.TryCompare(one, two, CreateChainer());
+                    (bool, IEnumerable<Difference>) result = TestInstance.TryCompare(one, two, CreateChainer());
 
-                Tools.Asserter.Is(true, result.Item1,
-                    $"Hint '{typeof(T).Name}' failed to support '{type.Name}'.");
-                Tools.Asserter.IsNotEmpty(result.Item2.ToArray(),
-                    $"Hint '{typeof(T).Name}' didn't find differences with two random '{type.Name}'.");
+                    Tools.Asserter.Is(true, result.Item1,
+                        $"Hint '{typeof(T).Name}' failed to support '{type.Name}'.");
+                    Tools.Asserter.IsNotEmpty(result.Item2.ToArray(),
+                        $"Hint '{typeof(T).Name}' didn't find differences with two random '{type.Name}'.");
+                }
+                catch (Exception e)
+                {
+                    ExpandReflectionException(e);
+                    throw;
+                }
+                finally
+                {
+                    (one as IDisposable)?.Dispose();
+                    (two as IDisposable)?.Dispose();
+                }
             }
         }
 
@@ -79,12 +107,26 @@ namespace CreateAndFakeTests.TestBases
         {
             foreach (Type type in _invalidTypes)
             {
-                object one = Tools.Randomizer.Create(type);
-                object two = Tools.Randomizer.Create(one.GetType());
+                object one = null, two = null;
+                try
+                {
+                    one = Tools.Randomizer.Create(type);
+                    two = Tools.Randomizer.Create(one.GetType());
 
-                Tools.Asserter.Is((false, (IEnumerable<Difference>)null),
-                    TestInstance.TryCompare(one, two, CreateChainer()),
-                    $"Hint '{typeof(T).Name}' should not support type '{type.Name}'.");
+                    Tools.Asserter.Is((false, (IEnumerable<Difference>)null),
+                        TestInstance.TryCompare(one, two, CreateChainer()),
+                        $"Hint '{typeof(T).Name}' should not support type '{type.Name}'.");
+                }
+                catch (Exception e)
+                {
+                    ExpandReflectionException(e);
+                    throw;
+                }
+                finally
+                {
+                    (one as IDisposable)?.Dispose();
+                    (two as IDisposable)?.Dispose();
+                }
             }
         }
 
@@ -107,6 +149,11 @@ namespace CreateAndFakeTests.TestBases
                         $"Hint '{typeof(T).Name}' generated different hash for same '{type.Name}'.");
                     Tools.Asserter.Is(dataHash, TestInstance.TryGetHashCode(dataCopy, CreateChainer()),
                         $"Hint '{typeof(T).Name}' generated different hash for dupe '{type.Name}'.");
+                }
+                catch (Exception e)
+                {
+                    ExpandReflectionException(e);
+                    throw;
                 }
                 finally
                 {
@@ -134,6 +181,11 @@ namespace CreateAndFakeTests.TestBases
                     Tools.Asserter.IsNot(dataHash, TestInstance.TryGetHashCode(dataDiffer, CreateChainer()),
                         $"Hint '{typeof(T).Name}' generated same hash for different '{type.Name}'.");
                 }
+                catch (Exception e)
+                {
+                    ExpandReflectionException(e);
+                    throw;
+                }
                 finally
                 {
                     (data as IDisposable)?.Dispose();
@@ -148,9 +200,24 @@ namespace CreateAndFakeTests.TestBases
         {
             foreach (Type type in _invalidTypes)
             {
-                Tools.Asserter.Is((false, default(int)),
-                    TestInstance.TryGetHashCode(Tools.Randomizer.Create(type), CreateChainer()),
-                    $"Hint '{typeof(T).Name}' should not support type '{type.Name}'.");
+                object data = null;
+                try
+                {
+                    data = Tools.Randomizer.Create(type);
+
+                    Tools.Asserter.Is((false, default(int)),
+                        TestInstance.TryGetHashCode(data, CreateChainer()),
+                        $"Hint '{typeof(T).Name}' should not support type '{type.Name}'.");
+                }
+                catch (Exception e)
+                {
+                    ExpandReflectionException(e);
+                    throw;
+                }
+                finally
+                {
+                    (data as IDisposable)?.Dispose();
+                }
             }
         }
 
@@ -160,6 +227,20 @@ namespace CreateAndFakeTests.TestBases
             return new ValuerChainer(Tools.Valuer,
                 (o, c) => Tools.Valuer.GetHashCode(o),
                 (e, a, c) => Tools.Valuer.Compare(e, a));
+        }
+
+        private void ExpandReflectionException(Exception ex)
+        {
+            if (ex is ReflectionTypeLoadException refEx)
+            {
+                throw new InvalidOperationException(
+                    "Reflection failure:" + refEx.LoaderExceptions.Select(e => e.Message), ex);
+            }
+            else if (ex.InnerException is ReflectionTypeLoadException refExInner)
+            {
+                throw new InvalidOperationException(
+                    "Reflection failure:" + refExInner.LoaderExceptions.Select(e => e.Message), ex);
+            }
         }
     }
 }

--- a/tests/CreateAndFakeTests/Toolbox/AsserterTool/Fluent/AssertChainerTests.cs
+++ b/tests/CreateAndFakeTests/Toolbox/AsserterTool/Fluent/AssertChainerTests.cs
@@ -1,0 +1,28 @@
+﻿using CreateAndFake;
+using CreateAndFake.Toolbox.AsserterTool.Fluent;
+using Xunit;
+
+namespace CreateAndFakeTests.Toolbox.AsserterTool.Fluent
+{
+    /// <summary>Verifies behavior.</summary>
+    public static class AssertChainerTests
+    {
+        [Fact]
+        internal static void AssertChainer_GuardsNulls()
+        {
+            Tools.Tester.PreventsNullRefException<AssertChainer<object>>();
+        }
+
+        [Fact]
+        internal static void AssertChainer_NoParameterMutation()
+        {
+            Tools.Tester.PreventsParameterMutation<AssertChainer<object>>();
+        }
+
+        [Theory, RandomData]
+        internal static void And_PassesBackInstance(object data)
+        {
+            Tools.Asserter.Is(data, new AssertChainer<object>(data).And);
+        }
+    }
+}

--- a/tests/CreateAndFakeTests/Toolbox/AsserterTool/Fluent/AssertCollectionTests.cs
+++ b/tests/CreateAndFakeTests/Toolbox/AsserterTool/Fluent/AssertCollectionTests.cs
@@ -1,0 +1,22 @@
+﻿using CreateAndFake;
+using CreateAndFake.Toolbox.AsserterTool.Fluent;
+using Xunit;
+
+namespace CreateAndFakeTests.Toolbox.AsserterTool.Fluent
+{
+    /// <summary>Verifies behavior.</summary>
+    public static class AssertCollectionTests
+    {
+        [Fact]
+        internal static void AssertCollection_GuardsNulls()
+        {
+            Tools.Tester.PreventsNullRefException<AssertCollection>();
+        }
+
+        [Fact]
+        internal static void AssertCollection_NoParameterMutation()
+        {
+            Tools.Tester.PreventsParameterMutation<AssertCollection>();
+        }
+    }
+}

--- a/tests/CreateAndFakeTests/Toolbox/AsserterTool/Fluent/AssertObjectTests.cs
+++ b/tests/CreateAndFakeTests/Toolbox/AsserterTool/Fluent/AssertObjectTests.cs
@@ -1,0 +1,22 @@
+﻿using CreateAndFake;
+using CreateAndFake.Toolbox.AsserterTool.Fluent;
+using Xunit;
+
+namespace CreateAndFakeTests.Toolbox.AsserterTool.Fluent
+{
+    /// <summary>Verifies behavior.</summary>
+    public static class AssertObjectTests
+    {
+        [Fact]
+        internal static void AssertObject_GuardsNulls()
+        {
+            Tools.Tester.PreventsNullRefException<AssertObject>();
+        }
+
+        [Fact]
+        internal static void AssertObject_NoParameterMutation()
+        {
+            Tools.Tester.PreventsParameterMutation<AssertObject>();
+        }
+    }
+}

--- a/tests/CreateAndFakeTests/Toolbox/ValuerTool/CompareHints/FakedCompareHintTests.cs
+++ b/tests/CreateAndFakeTests/Toolbox/ValuerTool/CompareHints/FakedCompareHintTests.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections;
-using System.Linq;
-using System.Reflection;
 using CreateAndFake.Toolbox.FakerTool.Proxy;
 using CreateAndFake.Toolbox.ValuerTool.CompareHints;
 using CreateAndFakeTests.TestBases;
@@ -22,28 +20,5 @@ namespace CreateAndFakeTests.Toolbox.ValuerTool.CompareHints
 
         /// <summary>Sets up the tests.</summary>
         public FakedCompareHintTests() : base(_TestInstance, _ValidTypes, _InvalidTypes) { }
-
-        /// <summary>Verifies the hint supports the correct types.</summary>
-        public override void TryCompare_SupportsDifferentValidTypes()
-        {
-            try
-            {
-                base.TryCompare_SupportsDifferentValidTypes();
-            }
-            catch (Exception ex)
-            {
-                if (ex is ReflectionTypeLoadException refEx)
-                {
-                    throw new InvalidOperationException(
-                        "Reflection failure:" + refEx.LoaderExceptions.Select(e => e.Message), ex);
-                }
-                else if (ex.InnerException is ReflectionTypeLoadException refExInner)
-                {
-                    throw new InvalidOperationException(
-                        "Reflection failure:" + refExInner.LoaderExceptions.Select(e => e.Message), ex);
-                }
-                throw;
-            }
-        }
     }
 }

--- a/tests/CreateAndFakeTests/ToolsTests.cs
+++ b/tests/CreateAndFakeTests/ToolsTests.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using CreateAndFake;
 using CreateAndFake.Toolbox;
+using CreateAndFake.Toolbox.AsserterTool.Fluent;
 using CreateAndFake.Toolbox.DuplicatorTool;
 using CreateAndFake.Toolbox.FakerTool;
 using CreateAndFake.Toolbox.RandomizerTool;
@@ -61,8 +62,20 @@ namespace CreateAndFakeTests
         [Fact]
         internal static void Tools_AllCreateAndFakeTypesWork()
         {
-            Type[] ignore = new[] { typeof(Arg), typeof(Fake), typeof(Fake<>), typeof(VoidType), typeof(AnyGeneric),
-                typeof(Injected<>), typeof(DuplicatorChainer), typeof(ValuerChainer), typeof(Behavior), typeof(Behavior<>) };
+            Type[] ignore = new[] {
+                typeof(Arg),
+                typeof(Fake),
+                typeof(Fake<>),
+                typeof(VoidType),
+                typeof(AnyGeneric),
+                typeof(Injected<>),
+                typeof(DuplicatorChainer),
+                typeof(ValuerChainer),
+                typeof(Behavior),
+                typeof(Behavior<>),
+                typeof(AssertObjectBase<>),
+                typeof(AssertCollectionBase<>)
+            };
 
             foreach (Type type in typeof(Tools).Assembly.GetTypes()
                 .Where(t => !(t.IsAbstract && t.IsSealed))


### PR DESCRIPTION
<!--- Follow the contributing guide and code of conduct. --->

## Summary
<!--- Describe the code. --->
Adds assert chaining and assert extensions for objects.

## Fulfills
<!--- Specify which issues the contribution solves. --->

* Closes #56: Add Fluent Assert
