### PR TITLE
Fix 58, 59: .NET Core 3.0 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 dist: xenial
 language: csharp
 mono: none
-dotnet: 2.2.100
+dotnet: 3.0
 script:
  - bash ./build/build.sh OnTravis

--- a/build/nuke/Build.cs
+++ b/build/nuke/Build.cs
@@ -152,11 +152,11 @@ internal class Build : NukeBuild
         {
             DotNetTasks.DotNetBuild(s => s
                 .SetProjectFile(_solution)
-                .SetFramework("netcoreapp2.0"));
+                .SetFramework("netcoreapp3.0"));
 
             DotNetTasks.DotNetTest(s => s
                 .SetProjectFile(_solution)
-                .SetFramework("netcoreapp2.0")
+                .SetFramework("netcoreapp3.0")
                 .SetNoBuild(true));
         });
 }

--- a/build/nuke/_Build.csproj
+++ b/build/nuke/_Build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RootNamespace></RootNamespace>
     <IsPackable>false</IsPackable>
@@ -11,9 +11,9 @@
 
   <ItemGroup>
     <PackageReference Include="Nuke.Common" Version="0.22.2" />
-    <PackageReference Include="GitVersion.CommandLine.DotNetCore" Version="5.0.1" />
+    <PackageReference Include="GitVersion.CommandLine.DotNetCore" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="ReportGenerator" Version="4.2.20" />
-    <PackageReference Include="coverlet.console" Version="1.5.1" ExcludeAssets="All" />
+    <PackageReference Include="coverlet.console" Version="1.6.0" ExcludeAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CreateAndFake/CreateAndFake.csproj
+++ b/src/CreateAndFake/CreateAndFake.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp2.0;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/CreateAndFake/CreateAndFake.csproj
+++ b/src/CreateAndFake/CreateAndFake.csproj
@@ -31,9 +31,9 @@
 
   <ItemGroup Condition="'$(OS)'=='Windows_NT'">
     <PackageReference Include="Microsoft.AnalyzerPowerPack" Version="1.1.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.3.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.6" PrivateAssets="All" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="7.17.0.9346" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.4.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8" PrivateAssets="All" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.0.0.9566" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/CreateAndFake/Toolbox/FakerTool/Proxy/Emitter.cs
+++ b/src/CreateAndFake/Toolbox/FakerTool/Proxy/Emitter.cs
@@ -1,0 +1,292 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+
+namespace CreateAndFake.Toolbox.FakerTool.Proxy
+{
+    /// <summary>Creates dynamic subclasses by IL code.</summary>
+    [SuppressMessage("Sonar", "S125:RemoveCommentedCode", Justification = "Documents emit code.")]
+    internal static class Emitter
+    {
+        /// <summary>Assembly used to contain the dynamic types.</summary>
+        internal static AssemblyName AssemblyName { get; } = new AssemblyName("FakerTypes");
+
+        /// <summary>Underlying type managing implementation details.</summary>
+        internal static Type FakeType { get; } = typeof(IFaked);
+
+        /// <summary>Underlying type managing implementation details.</summary>
+        internal static Type MetaType { get; } = typeof(FakeMetaProvider);
+
+        /// <summary>Flags used to find members to implement.</summary>
+        private const BindingFlags _MemberFinder = BindingFlags.FlattenHierarchy |
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+
+        /// <summary>Methods called to chain fake calls.</summary>
+        private static readonly MethodInfo
+            _VoidChainer = MetaType.GetMethod(
+                nameof(FakeMetaProvider.CallVoid),
+                BindingFlags.Instance | BindingFlags.NonPublic),
+            _ResultChainer = MetaType.GetMethod(
+                nameof(FakeMetaProvider.CallRet),
+                BindingFlags.Instance | BindingFlags.NonPublic),
+            _TypeResolver = typeof(Type).GetMethod(
+                nameof(Type.GetTypeFromHandle),
+                BindingFlags.Static | BindingFlags.Public);
+
+        /// <summary>Module storing the faked types.</summary>
+        private static readonly ModuleBuilder _Module = AssemblyBuilder
+            .DefineDynamicAssembly(AssemblyName, AssemblyBuilderAccess.RunAndCollect)
+            .DefineDynamicModule("FakerTypesModule");
+
+        /// <summary>Creates a type with the given inheritence.</summary>
+        /// <param name="parent">Base class inheriting from.</param>
+        /// <param name="interfaces">Additional interfaces to inherit.</param>
+        /// <returns>Dynamic type with behavior faked.</returns>
+        internal static TypeInfo BuildType(Type parent, Type[] interfaces)
+        {
+            TypeBuilder newType = _Module.DefineType(
+                "Fake[" + string.Join("|", interfaces.Prepend(parent).Select(i => i.Name)) + "]-" + Guid.NewGuid(),
+                TypeAttributes.NotPublic | TypeAttributes.Sealed, parent, interfaces);
+
+            MethodInfo metaGetter = SetupFakeMetaProvider(newType, parent);
+
+            (PropertyInfo, PropertyBuilder)[] props =
+                FindImplementableProperties(interfaces.Prepend(parent))
+                .Select(p => (p, newType.DefineProperty(
+                    p.DeclaringType.Name + "." + p.Name,
+                    p.Attributes,
+                    p.PropertyType,
+                    Type.EmptyTypes)))
+                .ToArray();
+
+            foreach (MethodInfo method in FindImplementableMethods(interfaces.Prepend(parent)))
+            {
+                MethodBuilder fakedMethod = newType.DefineMethod(
+                    method.DeclaringType.Name + "." + method.Name,
+                    method.Attributes & ~MethodAttributes.Abstract,
+                    method.ReturnType,
+                    method.GetParameters().Select(p => p.ParameterType).ToArray());
+
+                if (method.IsGenericMethod)
+                {
+                    fakedMethod.DefineGenericParameters(method.GetGenericArguments().Select(a => a.Name).ToArray());
+                }
+                ImplementFakeBehavior(fakedMethod.GetILGenerator(), method, metaGetter);
+                newType.DefineMethodOverride(fakedMethod, method);
+
+                foreach ((PropertyInfo, PropertyBuilder) prop in props)
+                {
+                    if (prop.Item1.GetMethod == method)
+                    {
+                        prop.Item2.SetGetMethod(fakedMethod);
+                    }
+                    else if (prop.Item1.SetMethod == method)
+                    {
+                        prop.Item2.SetSetMethod(fakedMethod);
+                    }
+                }
+            }
+
+            return newType.CreateTypeInfo();
+        }
+
+        /// <summary>Finds all properties to generate for a type implementing the given interfaces.</summary>
+        /// <param name="interfaces">Interfaces to inherit.</param>
+        /// <returns>Properties to implement for the faked type.</returns>
+        private static IEnumerable<PropertyInfo> FindImplementableProperties(IEnumerable<Type> interfaces)
+        {
+            return interfaces
+                .Where(t => t != typeof(IFaked))
+                .SelectMany(i => i
+                    .GetProperties(_MemberFinder)
+                    .Where(p => IsVisible(p.GetMethod))
+                    .Concat(FindImplementableProperties(i.GetInterfaces())))
+                .Distinct();
+        }
+
+        /// <summary>Finds all methods to generate for a type implementing the given interfaces.</summary>
+        /// <param name="interfaces">Interfaces to inherit.</param>
+        /// <returns>Methods to implement for the faked type.</returns>
+        private static IEnumerable<MethodInfo> FindImplementableMethods(IEnumerable<Type> interfaces)
+        {
+            return interfaces
+                .Where(t => t != typeof(IFaked))
+                .SelectMany(i => i
+                    .GetMethods(_MemberFinder)
+                    .Where(m => m.IsAbstract || (m.IsVirtual && !m.IsFinal))
+                    .Where(m => IsVisible(m))
+                    .Where(m => m.Name != "Finalize")
+                    .Concat(FindImplementableMethods(i.GetInterfaces())))
+                .Distinct();
+        }
+
+        /// <summary>Determines if the method is visible for faking.</summary>
+        /// <param name="method">Method to check.</param>
+        /// <returns>True if visible; false otherwise.</returns>
+        private static bool IsVisible(MethodInfo method)
+        {
+            if (method == null)
+            {
+                return true;
+            }
+
+            return !method.IsPrivate
+                && (!(method.IsAssembly || method.IsFamilyAndAssembly)
+                    || method.Module.Assembly.GetCustomAttributes<InternalsVisibleToAttribute>()
+                        .Any(a => a.AssemblyName == AssemblyName.Name));
+        }
+
+        /// <summary>Chains the call for a method.</summary>
+        /// <param name="gen">Generator for the fake method.</param>
+        /// <param name="method">Method being implemented.</param>
+        /// <param name="metaGetter">Hook for the meta provider to chain with.</param>
+        private static void ImplementFakeBehavior(ILGenerator gen, MethodInfo method, MethodInfo metaGetter)
+        {
+            ParameterInfo[] argInfos = method.GetParameters();
+            Type[] generics = method.GetGenericArguments();
+
+            // object[] args = new object[params.Length];
+            LocalBuilder args = gen.DeclareLocal(typeof(object[]));
+            gen.Emit(OpCodes.Ldc_I4, argInfos.Length);
+            gen.Emit(OpCodes.Newarr, typeof(object));
+            gen.Emit(OpCodes.Stloc, args);
+
+            // args[0..x] = params[0..x];
+            for (int i = 0; i < argInfos.Length; i++)
+            {
+                gen.Emit(OpCodes.Ldloc, args);
+                gen.Emit(OpCodes.Ldc_I4, i);
+                if (!argInfos[i].ParameterType.IsByRef)
+                {
+                    gen.Emit(OpCodes.Ldarg, i + 1);
+                    gen.Emit(OpCodes.Box, argInfos[i].ParameterType);
+                    gen.Emit(OpCodes.Stelem_Ref);
+                }
+                else
+                {
+                    // args[i] = new OutRef<T>();
+                    Type outRef = typeof(OutRef<>).MakeGenericType(argInfos[i].ParameterType.GetElementType());
+                    gen.Emit(OpCodes.Newobj, outRef.GetConstructor(Type.EmptyTypes));
+                    gen.Emit(OpCodes.Stelem_Ref);
+                    if (!argInfos[i].IsOut)
+                    {
+                        // ((OutRef<T>)args[i].Var) = params[i];
+                        gen.Emit(OpCodes.Ldloc, args);
+                        gen.Emit(OpCodes.Ldc_I4, i);
+                        gen.Emit(OpCodes.Ldelem_Ref);
+                        gen.Emit(OpCodes.Castclass, outRef);
+                        gen.Emit(OpCodes.Ldarg, i + 1);
+                        gen.Emit(OpCodes.Ldind_Ref);
+                        gen.Emit(OpCodes.Stfld, outRef.GetField(nameof(OutRef<Type>.Var)));
+                    }
+                }
+            }
+
+            // Type[] types = new Type[generics.Length];
+            LocalBuilder types = gen.DeclareLocal(typeof(Type[]));
+            gen.Emit(OpCodes.Ldc_I4, generics.Length);
+            gen.Emit(OpCodes.Newarr, typeof(Type));
+            gen.Emit(OpCodes.Stloc, types);
+
+            // types[0..x] = typeof(generics[0..x]);
+            for (int i = 0; i < generics.Length; i++)
+            {
+                gen.Emit(OpCodes.Ldloc, types);
+                gen.Emit(OpCodes.Ldc_I4, i);
+                gen.Emit(OpCodes.Ldtoken, generics[i]);
+                gen.Emit(OpCodes.Call, _TypeResolver);
+                gen.Emit(OpCodes.Stelem_Ref);
+            }
+
+            // this.FakeMeta.Call('method.Name', types, args);
+            gen.Emit(OpCodes.Ldarg_0);
+            gen.Emit(OpCodes.Call, metaGetter);
+            gen.Emit(OpCodes.Ldstr, method.Name);
+            gen.Emit(OpCodes.Ldloc, types);
+            gen.Emit(OpCodes.Ldloc, args);
+            if (method.ReturnType != typeof(void))
+            {
+                gen.Emit(OpCodes.Call, _ResultChainer.MakeGenericMethod(method.ReturnType));
+            }
+            else
+            {
+                gen.Emit(OpCodes.Call, _VoidChainer);
+            }
+
+            // params[0..x] = ((OutRef)args[0..x]).Var;
+            for (int i = 0; i < argInfos.Length; i++)
+            {
+                if (argInfos[i].ParameterType.IsByRef)
+                {
+                    Type outRef = typeof(OutRef<>).MakeGenericType(argInfos[i].ParameterType.GetElementType());
+
+                    gen.Emit(OpCodes.Ldarg, i + 1);
+                    gen.Emit(OpCodes.Ldloc, args);
+                    gen.Emit(OpCodes.Ldc_I4, i);
+                    gen.Emit(OpCodes.Ldelem_Ref);
+                    gen.Emit(OpCodes.Castclass, outRef);
+                    gen.Emit(OpCodes.Ldfld, outRef.GetField(nameof(OutRef<Type>.Var)));
+                    gen.Emit(OpCodes.Stind_Ref);
+                }
+            }
+
+            gen.Emit(OpCodes.Ret);
+        }
+
+        /// <summary>Hooks up the fake behavior mechanism for the new type.</summary>
+        /// <param name="newType">Dynamic type being created.</param>
+        /// <param name="parent">Base class inheriting from.</param>
+        /// <returns>Info for the meta provider hook.</returns>
+        private static MethodInfo SetupFakeMetaProvider(TypeBuilder newType, Type parent)
+        {
+            ConstructorInfo baseConstuctor = parent
+                .GetConstructors(_MemberFinder)
+                .SingleOrDefault(c => !c.GetParameters().Any());
+
+            FieldBuilder backingField = newType.DefineField(
+                newType.Name + ".m_" + nameof(IFaked.FakeMeta), MetaType,
+                FieldAttributes.Private | FieldAttributes.InitOnly);
+
+            ConstructorBuilder constructor = newType.DefineConstructor(
+                MethodAttributes.Public, CallingConventions.HasThis, new[] { MetaType });
+            {
+                // base();
+                ILGenerator newGenerator = constructor.GetILGenerator();
+                if (baseConstuctor != null)
+                {
+                    newGenerator.Emit(OpCodes.Ldarg_0);
+                    newGenerator.Emit(OpCodes.Call, baseConstuctor);
+                }
+
+                // this.m_FakeMeta = params[0];
+                newGenerator.Emit(OpCodes.Ldarg_0);
+                newGenerator.Emit(OpCodes.Ldarg_1);
+                newGenerator.Emit(OpCodes.Stfld, backingField);
+                newGenerator.Emit(OpCodes.Ret);
+            }
+
+            PropertyInfo propInfo = FakeType.GetProperty(nameof(IFaked.FakeMeta));
+            MethodInfo getterInfo = propInfo.GetGetMethod();
+
+            MethodBuilder getMetaMethod = newType.DefineMethod(nameof(IFaked) + "." + getterInfo.Name,
+                getterInfo.Attributes & ~MethodAttributes.Abstract, MetaType, Type.EmptyTypes);
+            {
+                // return this.m_FakeMeta;
+                ILGenerator getGenerator = getMetaMethod.GetILGenerator();
+                getGenerator.Emit(OpCodes.Ldarg_0);
+                getGenerator.Emit(OpCodes.Ldfld, backingField);
+                getGenerator.Emit(OpCodes.Ret);
+            }
+
+            newType.DefineProperty(nameof(IFaked) + "." + propInfo.Name,
+                propInfo.Attributes, MetaType, Type.EmptyTypes).SetGetMethod(getMetaMethod);
+
+            newType.DefineMethodOverride(getMetaMethod, getterInfo);
+            return getterInfo;
+        }
+    }
+}

--- a/src/CreateAndFake/Toolbox/TesterTool/BaseGuarder.cs
+++ b/src/CreateAndFake/Toolbox/TesterTool/BaseGuarder.cs
@@ -59,6 +59,7 @@ namespace CreateAndFake.Toolbox.TesterTool
             return type
                 .GetMethods(kind | BindingFlags.Public | BindingFlags.NonPublic)
                 .Where(m => m.IsPublic || m.IsAssembly || m.IsFamily || m.IsFamilyOrAssembly)
+                .Where(m => m.DeclaringType == type || m.DeclaringType.IsAbstract)
                 .Where(m => !m.IsPrivate);
         }
 

--- a/src/CreateAndFake/Toolbox/TesterTool/Tester.cs
+++ b/src/CreateAndFake/Toolbox/TesterTool/Tester.cs
@@ -202,8 +202,7 @@ namespace CreateAndFake.Toolbox.TesterTool
         /// <param name="injectionValues">Values to inject into called methods.</param>
         public virtual void PassthroughWithNoExceptions<T>(params object[] injectionValues)
         {
-            new ExceptionGuarder(new GenericFixer(Gen, Randomizer), Randomizer, Asserter, _timeout)
-                .CallAllMethods(Randomizer.Create<Injected<T>>().Dummy, injectionValues);
+            PassthroughWithNoExceptions(Randomizer.Create<Injected<T>>().Dummy, injectionValues);
         }
 
         /// <summary>Verifies no exceptions are thrown on any method.</summary>

--- a/tests/CreateAndFakeTests/CreateAndFakeTests.csproj
+++ b/tests/CreateAndFakeTests/CreateAndFakeTests.csproj
@@ -7,16 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(OS)'=='Windows_NT'">
     <PackageReference Include="Microsoft.AnalyzerPowerPack" Version="1.1.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.3.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.6" PrivateAssets="All" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="7.17.0.9346" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.4.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8" PrivateAssets="All" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.0.0.9566" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/CreateAndFakeTests/CreateAndFakeTests.csproj
+++ b/tests/CreateAndFakeTests/CreateAndFakeTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp3.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/CreateAndFakeTests/CreateAndFakeTests.csproj
+++ b/tests/CreateAndFakeTests/CreateAndFakeTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" PrivateAssets="All" />
   </ItemGroup>

--- a/tests/CreateAndFakeTests/CreateAndFakeTests.csproj
+++ b/tests/CreateAndFakeTests/CreateAndFakeTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp3.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp2.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/CreateAndFakeTests/Toolbox/TesterTool/MutationGuarderTests.cs
+++ b/tests/CreateAndFakeTests/Toolbox/TesterTool/MutationGuarderTests.cs
@@ -100,7 +100,7 @@ namespace CreateAndFakeTests.Toolbox.TesterTool
                 using (MockDisposableSample sample = new MockDisposableSample(null))
                 {
                     _LongTestInstance.PreventsMutationOnMethods(sample);
-                    Tools.Asserter.Is(1, MockDisposableSample._ClassDisposes);
+                    Tools.Asserter.Is(0, MockDisposableSample._ClassDisposes);
                     Tools.Asserter.Is(0, MockDisposableSample._FinalizerDisposes);
                     MockDisposableSample._Fake.Verify(Times.Once, d => d.Dispose());
                 }

--- a/tests/CreateAndFakeTests/Toolbox/TesterTool/TesterTests.cs
+++ b/tests/CreateAndFakeTests/Toolbox/TesterTool/TesterTests.cs
@@ -2,7 +2,11 @@
 using System.Linq;
 using System.Reflection;
 using CreateAndFake;
+using CreateAndFake.Design.Randomization;
+using CreateAndFake.Toolbox.AsserterTool;
+using CreateAndFake.Toolbox.DuplicatorTool;
 using CreateAndFake.Toolbox.FakerTool;
+using CreateAndFake.Toolbox.RandomizerTool;
 using CreateAndFake.Toolbox.TesterTool;
 using CreateAndFakeTests.Toolbox.TesterTool.TestSamples;
 using Xunit;
@@ -29,10 +33,17 @@ namespace CreateAndFakeTests.Toolbox.TesterTool
                 .Select(m => m.Name));
         }
 
-        [Fact]
-        internal static void Tester_GuardsNulls()
+        [Theory, RandomData]
+        internal static void Tester_GuardsNulls(IRandom gen, IRandomizer randomizer,
+            IDuplicator duplicator, Asserter asserter, TimeSpan? timeout)
         {
-            Tools.Tester.PreventsNullRefException(_ShortTestInstance);
+            Tools.Asserter.Throws<ArgumentNullException>(() => new Tester(null, randomizer, duplicator, asserter, timeout));
+            Tools.Asserter.Throws<ArgumentNullException>(() => new Tester(gen, null, duplicator, asserter, timeout));
+            Tools.Asserter.Throws<ArgumentNullException>(() => new Tester(gen, randomizer, null, asserter, timeout));
+            Tools.Asserter.Throws<ArgumentNullException>(() => new Tester(gen, randomizer, duplicator, null, timeout));
+
+            Tools.Asserter.Throws<ArgumentNullException>(() => _ShortTestInstance.PreventsNullRefException(null));
+            Tools.Asserter.Throws<ArgumentNullException>(() => _ShortTestInstance.PreventsParameterMutation(null));
         }
 
         [Fact]

--- a/tests/CreateAndFakeTests/Toolbox/TesterTool/TesterTests.cs
+++ b/tests/CreateAndFakeTests/Toolbox/TesterTool/TesterTests.cs
@@ -72,7 +72,7 @@ namespace CreateAndFakeTests.Toolbox.TesterTool
                 MockDisposableSample._Fake = Tools.Faker.Stub<IDisposable>();
 
                 _LongTestInstance.PreventsParameterMutation<MockDisposableSample>();
-                Tools.Asserter.Is(3, MockDisposableSample._ClassDisposes);
+                Tools.Asserter.Is(2, MockDisposableSample._ClassDisposes);
                 Tools.Asserter.Is(0, MockDisposableSample._FinalizerDisposes);
                 MockDisposableSample._Fake.Verify(Times.Exactly(2), d => d.Dispose());
             }

--- a/tests/CreateAndFakeTests/ToolsTests.cs
+++ b/tests/CreateAndFakeTests/ToolsTests.cs
@@ -7,6 +7,7 @@ using CreateAndFake.Toolbox;
 using CreateAndFake.Toolbox.AsserterTool.Fluent;
 using CreateAndFake.Toolbox.DuplicatorTool;
 using CreateAndFake.Toolbox.FakerTool;
+using CreateAndFake.Toolbox.FakerTool.Proxy;
 using CreateAndFake.Toolbox.RandomizerTool;
 using CreateAndFake.Toolbox.ValuerTool;
 using CreateAndFakeTests.TestSamples;
@@ -71,6 +72,7 @@ namespace CreateAndFakeTests
                 typeof(Injected<>),
                 typeof(DuplicatorChainer),
                 typeof(ValuerChainer),
+                typeof(Emitter),
                 typeof(Behavior),
                 typeof(Behavior<>),
                 typeof(AssertObjectBase<>),

--- a/tests/TestRules.ruleset
+++ b/tests/TestRules.ruleset
@@ -3,6 +3,7 @@
   <IncludeAll Action="Warning" />
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1303" Action="None" />
+    <Rule Id="CA1307" Action="None" />
     <Rule Id="CA1707" Action="None" />
   </Rules>
   <Rules AnalyzerId="SonarAnalyzer.CSharp" RuleNamespace="SonarAnalyzer.CSharp">


### PR DESCRIPTION
<!--- Follow the contributing guide and code of conduct. --->

## Summary
<!--- Describe the code. --->
Use .NET Core 3.0.
Switch OpCodes.Call to OpCodes.Callvirt.
Use top level calls for Tester.

## Fulfills
<!--- Specify which issues the contribution solves. --->

* Closes #58: Netcore 3.0 = Bad IL Format
* Closes #59: Add Top Level Auto Caller
