### PR TITLE
Fix #78: Add 'Also' to Fluent Assert

### DIFF
--- a/src/CreateAndFake/Toolbox/AsserterTool/Fluent/AssertChainer.cs
+++ b/src/CreateAndFake/Toolbox/AsserterTool/Fluent/AssertChainer.cs
@@ -1,17 +1,41 @@
-﻿namespace CreateAndFake.Toolbox.AsserterTool.Fluent
+﻿using System.Collections;
+using CreateAndFake.Toolbox.ValuerTool;
+
+namespace CreateAndFake.Toolbox.AsserterTool.Fluent
 {
     /// <summary>Allows assertion calls to be chained.</summary>
     /// <typeparam name="T">Assertion type to chain.</typeparam>
     public sealed class AssertChainer<T>
     {
+        /// <summary>Handles comparisons.</summary>
+        private readonly IValuer _valuer;
+
         /// <summary>Includes another assertion.</summary>
         public T And { get; }
 
         /// <summary>Initializer.</summary>
         /// <param name="chain">Assertion class to chain.</param>
-        public AssertChainer(T chain)
+        /// <param name="valuer">Handles comparisons.</param>
+        public AssertChainer(T chain, IValuer valuer)
         {
+            _valuer = valuer;
             And = chain;
+        }
+
+        /// <summary>Specifies another value to test.</summary>
+        /// <param name="actual">Object to test.</param>
+        /// <returns>Asserter to test with.</returns>
+        public AssertObject Also(object actual)
+        {
+            return new AssertObject(_valuer, actual);
+        }
+
+        /// <summary>Specifies another value to test.</summary>
+        /// <param name="collection">Collection to test.</param>
+        /// <returns>Asserter to test with.</returns>
+        public AssertGroup Also(IEnumerable collection)
+        {
+            return new AssertGroup(_valuer, collection);
         }
     }
 }

--- a/src/CreateAndFake/Toolbox/AsserterTool/Fluent/AssertObjectBase.cs
+++ b/src/CreateAndFake/Toolbox/AsserterTool/Fluent/AssertObjectBase.cs
@@ -115,7 +115,7 @@ namespace CreateAndFake.Toolbox.AsserterTool.Fluent
         /// <returns>The created chainer.</returns>
         protected AssertChainer<T> ToChainer()
         {
-            return new AssertChainer<T>((T)this);
+            return new AssertChainer<T>((T)this, Valuer);
         }
     }
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,8 +4,8 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <BaseIntermediateOutputPath>..\..\artifacts\obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
-    <OutputPath>..\..\artifacts\bin\$(Configuration)\$(MSBuildProjectName)\</OutputPath>
-    <DocumentationFile>..\..\artifacts\bin\$(Configuration)\$(MSBuildProjectName)\$(TargetFramework)\$(MSBuildProjectName).xml</DocumentationFile>
+    <OutputPath>..\..\artifacts\bin\$(MSBuildProjectName)\$(Configuration)\</OutputPath>
+    <DocumentationFile>..\..\artifacts\bin\$(MSBuildProjectName)\$(Configuration)\$(TargetFramework)\$(MSBuildProjectName).xml</DocumentationFile>
     <CodeAnalysisRuleSet>..\SourceRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 </Project>

--- a/tests/CreateAndFakeTests/IssueReplication/Issue002Tests.cs
+++ b/tests/CreateAndFakeTests/IssueReplication/Issue002Tests.cs
@@ -1,0 +1,16 @@
+using CreateAndFake.Fluent;
+using CreateAndFake.Toolbox.FakerTool.Proxy;
+using Xunit;
+
+namespace CreateAndFakeTests.IssueReplication
+{
+    /// <summary>Verifies issue is resolved.</summary>
+    public static class Issue002Tests
+    {
+        [Fact]
+        internal static void Issue_CallDataEncapsulated()
+        {
+            typeof(CallData).IsPublic.Assert().Is(false);
+        }
+    }
+}

--- a/tests/CreateAndFakeTests/IssueReplication/Issue003Tests.cs
+++ b/tests/CreateAndFakeTests/IssueReplication/Issue003Tests.cs
@@ -1,0 +1,56 @@
+using System.Diagnostics.CodeAnalysis;
+using CreateAndFake;
+using CreateAndFake.Fluent;
+using CreateAndFake.Toolbox.FakerTool;
+using Xunit;
+
+namespace CreateAndFakeTests.IssueReplication
+{
+    /// <summary>Verifies issue is resolved.</summary>
+    public static class Issue003Tests
+    {
+        /// <summary>For testing.</summary>
+        [SuppressMessage("Microsoft.Design", "CA1034:NestedTypesVisible", Justification = "For testing.")]
+        public abstract class RefHolder
+        {
+            /// <summary>For testing.</summary>
+            public abstract int TestMethodA(out int value);
+
+            /// <summary>For testing.</summary>
+            public abstract int TestMethodB(ref int value);
+        }
+
+        [Theory, RandomData]
+        internal static void Issue_FakeHandlesOut(Fake<RefHolder> sample, int testValue, int result)
+        {
+            sample.Setup(
+                d => d.TestMethodA(out Arg.AnyRef<int>().Var),
+                Behavior.Set((OutRef<int> v) =>
+                {
+                    v.Var = testValue;
+                    return result;
+                }));
+
+            sample.Dummy.TestMethodA(out int newValue).Assert().Is(result);
+            sample.VerifyAll();
+            newValue.Assert().Is(testValue);
+        }
+
+        [Theory, RandomData]
+        internal static void Issue_FakeHandlesRef(Fake<RefHolder> sample, int result)
+        {
+            int testValue = 0;
+            sample.Setup(
+                d => d.TestMethodB(ref Arg.AnyRef<int>().Var),
+                Behavior.Set((OutRef<int> v) =>
+                {
+                    v.Var -= 5;
+                    return result;
+                }));
+
+            sample.Dummy.TestMethodB(ref testValue).Assert().Is(result);
+            sample.VerifyAll();
+            testValue.Assert().Is(-5);
+        }
+    }
+}

--- a/tests/CreateAndFakeTests/IssueReplication/Issue012Tests.cs
+++ b/tests/CreateAndFakeTests/IssueReplication/Issue012Tests.cs
@@ -1,0 +1,26 @@
+using System.Diagnostics.CodeAnalysis;
+using CreateAndFake;
+using CreateAndFake.Fluent;
+using CreateAndFake.Toolbox.FakerTool;
+using Xunit;
+
+namespace CreateAndFakeTests.IssueReplication
+{
+    /// <summary>Verifies issue is resolved.</summary>
+    public static class Issue012Tests
+    {
+        /// <summary>For testing.</summary>
+        [SuppressMessage("Microsoft.Design", "CA1034:NestedTypesVisible", Justification = "For testing.")]
+        public abstract class Sample
+        {
+            /// <summary>For testing.</summary>
+            public abstract double Value();
+        }
+
+        [Theory, RandomData]
+        internal static void Issue_RandomizedFake(Fake<Sample> sample)
+        {
+            sample.Dummy.Value().Assert().IsNot(sample.Dummy.Value());
+        }
+    }
+}

--- a/tests/CreateAndFakeTests/IssueReplication/Issue015Tests.cs
+++ b/tests/CreateAndFakeTests/IssueReplication/Issue015Tests.cs
@@ -1,0 +1,27 @@
+using System;
+using CreateAndFake;
+using Xunit;
+
+namespace CreateAndFakeTests.IssueReplication
+{
+    /// <summary>Verifies issue is resolved.</summary>
+    public static class Issue015Tests
+    {
+        internal static class Sample
+        {
+            public static void Bad(int[] value)
+            {
+                if (value == null) throw new ArgumentNullException(nameof(value));
+
+                value[0] = Tools.Mutator.Variant(value[0]);
+            }
+        }
+
+        [Fact]
+        internal static void Issue_GuardsParameterMutation()
+        {
+            Tools.Asserter.Throws<AggregateException>(() =>
+                Tools.Tester.PreventsParameterMutation(typeof(Sample)));
+        }
+    }
+}

--- a/tests/CreateAndFakeTests/IssueReplication/Issue016Tests.cs
+++ b/tests/CreateAndFakeTests/IssueReplication/Issue016Tests.cs
@@ -1,0 +1,23 @@
+using CreateAndFake;
+using CreateAndFake.Fluent;
+using Xunit;
+
+namespace CreateAndFakeTests.IssueReplication
+{
+    /// <summary>Verifies issue is resolved.</summary>
+    public static class Issue016Tests
+    {
+        internal class Sample
+        {
+            public static int ValueA = 0;
+
+            public int ValueB = 0;
+        }
+
+        [Theory, RandomData]
+        internal static void Issue_StaticsNotRandomized(Sample sample)
+        {
+            sample.ValueB.Assert().IsNot(0).Also(Sample.ValueA).Is(0);
+        }
+    }
+}

--- a/tests/CreateAndFakeTests/IssueReplication/Issue065Tests.cs
+++ b/tests/CreateAndFakeTests/IssueReplication/Issue065Tests.cs
@@ -5,7 +5,7 @@ using Xunit;
 namespace CreateAndFakeTests.IssueReplication
 {
     /// <summary>Verifies issue is resolved.</summary>
-    public static class Issue65Tests
+    public static class Issue065Tests
     {
         internal class InfiniteA
         {

--- a/tests/CreateAndFakeTests/IssueReplication/Issue067Tests.cs
+++ b/tests/CreateAndFakeTests/IssueReplication/Issue067Tests.cs
@@ -5,7 +5,7 @@ using Xunit;
 namespace CreateAndFakeTests.IssueReplication
 {
     /// <summary>Verifies issue is resolved.</summary>
-    public static class Issue67Tests
+    public static class Issue067Tests
     {
         [Fact]
         internal static void Issue_SupportsUri()

--- a/tests/CreateAndFakeTests/IssueReplication/Issue078Tests.cs
+++ b/tests/CreateAndFakeTests/IssueReplication/Issue078Tests.cs
@@ -1,0 +1,22 @@
+using CreateAndFake;
+using CreateAndFake.Fluent;
+using Xunit;
+
+namespace CreateAndFakeTests.IssueReplication
+{
+    /// <summary>Verifies issue is resolved.</summary>
+    public static class Issue078Tests
+    {
+        [Theory, RandomData]
+        internal static void Issue_CanChainObjects(int[] valueA, bool valueB)
+        {
+            valueA.Assert().IsNotEmpty().Also(valueB).IsNot(null);
+        }
+
+        [Theory, RandomData]
+        internal static void Issue_CanChainCollections(bool valueA, int[] valueB)
+        {
+            valueA.Assert().IsNot(null).Also(valueB).IsNotEmpty();
+        }
+    }
+}

--- a/tests/CreateAndFakeTests/Toolbox/AsserterTool/Fluent/AssertChainerTests.cs
+++ b/tests/CreateAndFakeTests/Toolbox/AsserterTool/Fluent/AssertChainerTests.cs
@@ -22,7 +22,7 @@ namespace CreateAndFakeTests.Toolbox.AsserterTool.Fluent
         [Theory, RandomData]
         internal static void And_PassesBackInstance(object data)
         {
-            Tools.Asserter.Is(data, new AssertChainer<object>(data).And);
+            Tools.Asserter.Is(data, new AssertChainer<object>(data, Tools.Valuer).And);
         }
     }
 }

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -5,8 +5,8 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <BaseIntermediateOutputPath>..\..\artifacts\obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
-    <OutputPath>..\..\artifacts\testing\$(Configuration)\$(MSBuildProjectName)\</OutputPath>
-    <DocumentationFile>..\..\artifacts\testing\$(Configuration)\$(MSBuildProjectName)\$(TargetFramework)\$(MSBuildProjectName).xml</DocumentationFile>
+    <OutputPath>..\..\artifacts\bin\$(MSBuildProjectName)\$(Configuration)\</OutputPath>
+    <DocumentationFile>..\..\artifacts\bin\$(MSBuildProjectName)\$(Configuration)\$(TargetFramework)\$(MSBuildProjectName).xml</DocumentationFile>
     <RunSettingsFilePath>..\TestSettings.runsettings</RunSettingsFilePath>
     <CodeAnalysisRuleSet>..\TestRules.ruleset</CodeAnalysisRuleSet>
     <IsTestProject>true</IsTestProject>

--- a/tests/TestSettings.runsettings
+++ b/tests/TestSettings.runsettings
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RunSettings>
   <RunConfiguration>
-    <ResultsDirectory>../artifacts/testResults</ResultsDirectory>
+    <ResultsDirectory>../artifacts/testing</ResultsDirectory>
   </RunConfiguration>
 </RunSettings>


### PR DESCRIPTION
<!--- Follow the contributing guide and code of conduct. --->

## Summary
<!--- Describe the code. --->
Fix bin artifact paths.
Add assert 'Also' chain.
Add issue replication tests.

## Fulfills
<!--- Specify which issues the contribution solves. --->

* Closes #78: Add 'Also' to Fluent Assert
