### PR TITLE
Fix #81: Use seeds for default randomization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,6 @@ View the [license](LICENSE.txt) file for more details.
 * [xUnit](https://xunit.github.io/): For running tests.
 * [Coverlet](https://github.com/tonerdo/coverlet) + [ReportGenerator](https://danielpalme.github.io/ReportGenerator/) + [CodeCov](https://codecov.io/): For test coverage.
 * [Bullseye](https://github.com/adamralph/bullseye) + [SimpleExec](https://github.com/adamralph/simple-exec) + [MinVer](https://github.com/adamralph/minver): For project building.
-* [Sonar](https://www.sonarsource.com/products/codeanalyzers/sonarcsharp.html) + [Codacy](https://www.codacy.com/): For code analysis.
+* [Codacy](https://www.codacy.com/): For code analysis.
 * [GitHub](https://github.com/): For hosting code.
 * [Microsoft](https://visualstudio.microsoft.com/vs/features/net-development/): For C# and editors.

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -23,12 +23,3 @@ dotnet_diagnostic.IDE0048.severity = none
 dotnet_diagnostic.IDE0063.severity = none
 # IDE0079: Remove unnecessary suppression
 dotnet_diagnostic.IDE0079.severity = none
-
-# S1125: Boolean literals should not be redundant
-dotnet_diagnostic.S1125.severity = silent
-# S1199: Nested code blocks should not be used
-dotnet_diagnostic.S1199.severity = none
-# S3443: Type should not be examined on "System.Type" instances
-dotnet_diagnostic.S3443.severity = none
-# S4457: Parameter validation in "async"/"await" methods should be wrapped
-dotnet_diagnostic.S4457.severity = none

--- a/src/CreateAndFake/CreateAndFake.csproj
+++ b/src/CreateAndFake/CreateAndFake.csproj
@@ -30,7 +30,6 @@
     <PackageReference Include="MinVer" Version="2.4.0" PrivateAssets="All" />
     <PackageReference Include="xunit.core" Version="2.2.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="3.8.0" PrivateAssets="All" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.17.0.26580" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/CreateAndFake/Design/Randomization/FastRandom.cs
+++ b/src/CreateAndFake/Design/Randomization/FastRandom.cs
@@ -7,6 +7,9 @@ namespace CreateAndFake.Design.Randomization
     /// <summary>For generating quick but insecure random values.</summary>
     public sealed class FastRandom : ValueRandom
     {
+        /// <summary>Initial seed used by the instance if there is one.</summary>
+        public override int? InitialSeed { get; } = null;
+
         /// <summary>Source generator used for random bytes.</summary>
         private static readonly Random _Gen = new();
 

--- a/src/CreateAndFake/Design/Randomization/IRandom.cs
+++ b/src/CreateAndFake/Design/Randomization/IRandom.cs
@@ -9,6 +9,9 @@ namespace CreateAndFake.Design.Randomization
         MessageId = "Next", Justification = "Matches the Random convention.")]
     public interface IRandom
     {
+        /// <summary>Initial seed used by the instance if there is one.</summary>
+        int? InitialSeed { get; }
+
         /// <summary>Checks if the given type is supported for randomization.</summary>
         /// <typeparam name="T">Type to verify.</typeparam>
         /// <returns>True if supported; false otherwise.</returns>

--- a/src/CreateAndFake/Design/Randomization/SecureRandom.cs
+++ b/src/CreateAndFake/Design/Randomization/SecureRandom.cs
@@ -5,6 +5,9 @@ namespace CreateAndFake.Design.Randomization
     /// <summary>For generating secure but slow random values.</summary>
     public sealed class SecureRandom : ValueRandom
     {
+        /// <summary>Initial seed used by the instance if there is one.</summary>
+        public override int? InitialSeed { get; } = null;
+
         /// <summary>Source generator used for random bytes.</summary>
         private static readonly RandomNumberGenerator _Gen = RandomNumberGenerator.Create();
 

--- a/src/CreateAndFake/Design/Randomization/SeededRandom.cs
+++ b/src/CreateAndFake/Design/Randomization/SeededRandom.cs
@@ -20,7 +20,7 @@ namespace CreateAndFake.Design.Randomization
         }
 
         /// <summary>Initial seed used by the instance.</summary>
-        public int InitialSeed { get; }
+        public override int? InitialSeed { get; }
 
         /// <summary>Sets up the randomizer with the given seed.</summary>
         /// <param name="seed">Current seed to be used for the next randomized value.</param>
@@ -32,7 +32,7 @@ namespace CreateAndFake.Design.Randomization
         public SeededRandom(bool onlyValidValues, int? seed = null) : base(onlyValidValues)
         {
             InitialSeed = seed ?? Environment.TickCount;
-            _seed = InitialSeed;
+            _seed = InitialSeed.Value;
         }
 
         /// <summary>Generates a byte array filled with random bytes.</summary>

--- a/src/CreateAndFake/Design/Randomization/ValueRandom.cs
+++ b/src/CreateAndFake/Design/Randomization/ValueRandom.cs
@@ -52,7 +52,10 @@ namespace CreateAndFake.Design.Randomization
         public static ICollection<Type> ValueTypes { get; } = _Gens.Keys;
 
         /// <summary>Option to prevent generating invalid values.</summary>
-        protected bool OnlyValidValues { get; }
+        public bool OnlyValidValues { get; set; }
+
+        /// <summary>Initial seed used by the instance if there is one.</summary>
+        public abstract int? InitialSeed { get; }
 
         /// <summary>Sets up the randomizer.</summary>
         /// <param name="onlyValidValues">Option to prevent generating invalid values.</param>

--- a/src/CreateAndFake/Extensions/AssertExtensions.cs
+++ b/src/CreateAndFake/Extensions/AssertExtensions.cs
@@ -11,7 +11,7 @@ namespace CreateAndFake.Fluent
         /// <returns>Asserter to test with.</returns>
         public static AssertObject Assert(this object actual)
         {
-            return new AssertObject(Tools.Valuer, actual);
+            return new AssertObject(Tools.Gen, Tools.Valuer, actual);
         }
 
         /// <summary>Handles common test scenarios.</summary>
@@ -19,7 +19,7 @@ namespace CreateAndFake.Fluent
         /// <returns>Asserter to test with.</returns>
         public static AssertGroup Assert(this IEnumerable collection)
         {
-            return new AssertGroup(Tools.Valuer, collection);
+            return new AssertGroup(Tools.Gen, Tools.Valuer, collection);
         }
     }
 }

--- a/src/CreateAndFake/Toolbox/AsserterTool/AssertException.cs
+++ b/src/CreateAndFake/Toolbox/AsserterTool/AssertException.cs
@@ -16,24 +16,27 @@ namespace CreateAndFake.Toolbox.AsserterTool
         /// <summary>Sets up the exception.</summary>
         /// <param name="message">Reason for the exception.</param>
         /// <param name="details">Optional fail details.</param>
+        /// <param name="seed">Seed used for data generation.</param>
         /// <param name="content">Optional related content.</param>
-        public AssertException(string message, string details, string content = null)
-            : base(BuildMessage(message, details, content)) { }
+        public AssertException(string message, string details, int? seed, string content = null)
+            : base(BuildMessage(message, details, seed, content)) { }
 
         /// <summary>Sets up the exception.</summary>
         /// <param name="message">Reason for the exception.</param>
         /// <param name="details">Optional fail details.</param>
+        /// <param name="seed">Seed used for data generation.</param>
         /// <param name="innerException">Inner exception that occurred.</param>
-        public AssertException(string message, string details, Exception innerException)
-            : base(BuildMessage(message, details), innerException) { }
+        public AssertException(string message, string details, int? seed, Exception innerException)
+            : base(BuildMessage(message, details, seed), innerException) { }
 
         /// <summary>Sets up the exception.</summary>
         /// <param name="message">Reason for the exception.</param>
         /// <param name="details">Optional fail details.</param>
+        /// <param name="seed">Seed used for data generation.</param>
         /// <param name="content">Optional related content.</param>
         /// <param name="innerException">Inner exception that occurred.</param>
-        public AssertException(string message, string details, string content, Exception innerException)
-            : base(BuildMessage(message, details, content), innerException) { }
+        public AssertException(string message, string details, int? seed, string content, Exception innerException)
+            : base(BuildMessage(message, details, seed, content), innerException) { }
 
         /// <summary>Serialization constructor.</summary>
         /// <param name="info">Object data.</param>
@@ -43,15 +46,17 @@ namespace CreateAndFake.Toolbox.AsserterTool
         /// <summary>Integrates the details into the message.</summary>
         /// <param name="message">Starting message.</param>
         /// <param name="details">Details to integrate.</param>
+        /// <param name="seed">Seed used for data generation.</param>
         /// <param name="content">Content to integrate.</param>
         /// <returns>Message to use for the exception.</returns>
-        private static string BuildMessage(string message, string details, string content = null)
+        private static string BuildMessage(string message, string details, int? seed, string content = null)
         {
             string nl = Environment.NewLine;
 
             return (message ?? "Unknown assert failure.") +
-                ((details == null) ? "" : $"{nl}Details: {details}") +
-                ((content == null) ? "" : $"{nl}Content: {nl}{content}");
+                ((details != null) ? $"{nl}Details: {details}" : "") +
+                ((seed.HasValue) ? $"{nl}Seed: {seed.Value}" : "") +
+                ((content != null) ? $"{nl}Content: {nl}{content}" : "");
         }
     }
 }

--- a/src/CreateAndFake/Toolbox/AsserterTool/Fluent/AssertChainer.cs
+++ b/src/CreateAndFake/Toolbox/AsserterTool/Fluent/AssertChainer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using CreateAndFake.Design.Randomization;
 using CreateAndFake.Toolbox.ValuerTool;
 
 namespace CreateAndFake.Toolbox.AsserterTool.Fluent
@@ -7,6 +8,9 @@ namespace CreateAndFake.Toolbox.AsserterTool.Fluent
     /// <typeparam name="T">Assertion type to chain.</typeparam>
     public sealed class AssertChainer<T>
     {
+        /// <summary>Core value random handler.</summary>
+        private readonly IRandom _gen;
+
         /// <summary>Handles comparisons.</summary>
         private readonly IValuer _valuer;
 
@@ -14,10 +18,12 @@ namespace CreateAndFake.Toolbox.AsserterTool.Fluent
         public T And { get; }
 
         /// <summary>Initializer.</summary>
+        /// <param name="gen">Core value random handler.</param>
         /// <param name="chain">Assertion class to chain.</param>
         /// <param name="valuer">Handles comparisons.</param>
-        public AssertChainer(T chain, IValuer valuer)
+        public AssertChainer(T chain, IRandom gen, IValuer valuer)
         {
+            _gen = gen;
             _valuer = valuer;
             And = chain;
         }
@@ -27,7 +33,7 @@ namespace CreateAndFake.Toolbox.AsserterTool.Fluent
         /// <returns>Asserter to test with.</returns>
         public AssertObject Also(object actual)
         {
-            return new AssertObject(_valuer, actual);
+            return new AssertObject(_gen, _valuer, actual);
         }
 
         /// <summary>Specifies another value to test.</summary>
@@ -35,7 +41,7 @@ namespace CreateAndFake.Toolbox.AsserterTool.Fluent
         /// <returns>Asserter to test with.</returns>
         public AssertGroup Also(IEnumerable collection)
         {
-            return new AssertGroup(_valuer, collection);
+            return new AssertGroup(_gen, _valuer, collection);
         }
     }
 }

--- a/src/CreateAndFake/Toolbox/AsserterTool/Fluent/AssertGroup.cs
+++ b/src/CreateAndFake/Toolbox/AsserterTool/Fluent/AssertGroup.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using CreateAndFake.Design.Randomization;
 using CreateAndFake.Toolbox.ValuerTool;
 
 namespace CreateAndFake.Toolbox.AsserterTool.Fluent
@@ -7,8 +8,9 @@ namespace CreateAndFake.Toolbox.AsserterTool.Fluent
     public sealed class AssertGroup : AssertGroupBase<AssertGroup>
     {
         /// <summary>Initializer.</summary>
+        /// <param name="gen">Core value random handler.</param>
         /// <param name="valuer">Handles comparisons.</param>
         /// <param name="collection">Collection to check.</param>
-        internal AssertGroup(IValuer valuer, IEnumerable collection) : base(valuer, collection) { }
+        internal AssertGroup(IRandom gen, IValuer valuer, IEnumerable collection) : base(gen, valuer, collection) { }
     }
 }

--- a/src/CreateAndFake/Toolbox/AsserterTool/Fluent/AssertGroupBase.cs
+++ b/src/CreateAndFake/Toolbox/AsserterTool/Fluent/AssertGroupBase.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Text;
+using CreateAndFake.Design.Randomization;
 using CreateAndFake.Toolbox.ValuerTool;
 
 namespace CreateAndFake.Toolbox.AsserterTool.Fluent
@@ -11,9 +12,10 @@ namespace CreateAndFake.Toolbox.AsserterTool.Fluent
         protected IEnumerable Collection { get; }
 
         /// <summary>Initializer.</summary>
+        /// <param name="gen">Core value random handler.</param>
         /// <param name="valuer">Handles comparisons.</param>
         /// <param name="collection">Collection to check.</param>
-        protected AssertGroupBase(IValuer valuer, IEnumerable collection) : base(valuer, collection)
+        protected AssertGroupBase(IRandom gen, IValuer valuer, IEnumerable collection) : base(gen, valuer, collection)
         {
             Collection = collection;
         }
@@ -33,7 +35,7 @@ namespace CreateAndFake.Toolbox.AsserterTool.Fluent
         /// <returns>Chainer to make additional assertions with.</returns>
         public AssertChainer<T> IsNotEmpty(string details = null)
         {
-            _ = new AssertObject(Valuer, Collection?.GetEnumerator().MoveNext()).Is(true, details);
+            _ = new AssertObject(Gen, Valuer, Collection?.GetEnumerator().MoveNext()).Is(true, details);
             return ToChainer();
         }
 
@@ -47,7 +49,7 @@ namespace CreateAndFake.Toolbox.AsserterTool.Fluent
             if (Collection == null)
             {
                 throw new AssertException(
-                    $"Expected collection of '{count}' elements, but was 'null'.", details);
+                    $"Expected collection of '{count}' elements, but was 'null'.", details, Gen.InitialSeed);
             }
 
             StringBuilder contents = new();
@@ -60,7 +62,8 @@ namespace CreateAndFake.Toolbox.AsserterTool.Fluent
             if (i != count)
             {
                 throw new AssertException(
-                    $"Expected collection of '{count}' elements, but was '{i}'.", details, contents.ToString());
+                    $"Expected collection of '{count}' elements, but was '{i}'.",
+                    details, Gen.InitialSeed, contents.ToString());
             }
 
             return ToChainer();

--- a/src/CreateAndFake/Toolbox/AsserterTool/Fluent/AssertObject.cs
+++ b/src/CreateAndFake/Toolbox/AsserterTool/Fluent/AssertObject.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using CreateAndFake.Design.Randomization;
 using CreateAndFake.Toolbox.ValuerTool;
 
 namespace CreateAndFake.Toolbox.AsserterTool.Fluent
@@ -7,9 +8,10 @@ namespace CreateAndFake.Toolbox.AsserterTool.Fluent
     public sealed class AssertObject : AssertObjectBase<AssertObject>
     {
         /// <summary>Sets up the asserter capabilities.</summary>
+        /// <param name="gen">Core value random handler.</param>
         /// <param name="valuer">Handles comparisons.</param>
         /// <param name="actual">Object to compare with.</param>
         /// <exception cref="ArgumentNullException">If given a null valuer.</exception>
-        internal AssertObject(IValuer valuer, object actual) : base(valuer, actual) { }
+        internal AssertObject(IRandom gen, IValuer valuer, object actual) : base(gen, valuer, actual) { }
     }
 }

--- a/src/CreateAndFake/Tools.cs
+++ b/src/CreateAndFake/Tools.cs
@@ -14,7 +14,7 @@ namespace CreateAndFake
     public static class Tools
     {
         /// <summary>Core value random handler.</summary>
-        public static IRandom Gen { get; } = new FastRandom();
+        public static IRandom Gen { get; } = new SeededRandom();
 
         /// <summary>Compares objects by value.</summary>
         public static IValuer Valuer { get; } = new Valuer();
@@ -29,7 +29,7 @@ namespace CreateAndFake
         public static IMutator Mutator { get; } = new Mutator(Randomizer, Valuer, Limiter.Dozen);
 
         /// <summary>Handles common test scenarios.</summary>
-        public static Asserter Asserter { get; } = new Asserter(Valuer);
+        public static Asserter Asserter { get; } = new Asserter(Gen, Valuer);
 
         /// <summary>Deep clones objects.</summary>
         public static IDuplicator Duplicator { get; } = new Duplicator(Asserter);

--- a/tests/.editorconfig
+++ b/tests/.editorconfig
@@ -32,8 +32,3 @@ dotnet_diagnostic.IDE0063.severity = none
 dotnet_diagnostic.IDE0058.severity = none
 # IDE0079: Remove unnecessary suppression
 dotnet_diagnostic.IDE0079.severity = none
-
-# S2699: Tests should include assertions
-dotnet_diagnostic.S2699.severity = none
-# S3443: Type should not be examined on "System.Type" instances
-dotnet_diagnostic.S3443.severity = none

--- a/tests/CreateAndFakeTests/CreateAndFakeTests.csproj
+++ b/tests/CreateAndFakeTests/CreateAndFakeTests.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" PrivateAssets="All" />
     <PackageReference Include="coverlet.collector" Version="3.0.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="3.8.0" PrivateAssets="All" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.17.0.26580" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/CreateAndFakeTests/IssueReplication/Issue081Tests.cs
+++ b/tests/CreateAndFakeTests/IssueReplication/Issue081Tests.cs
@@ -1,0 +1,24 @@
+using CreateAndFake;
+using CreateAndFake.Fluent;
+using CreateAndFake.Toolbox.AsserterTool;
+using Xunit;
+
+namespace CreateAndFakeTests.IssueReplication
+{
+    /// <summary>Verifies issue is resolved.</summary>
+    public static class Issue081Tests
+    {
+        [Fact]
+        internal static void Issue_RandomizationIsSeeded()
+        {
+            Tools.Gen.InitialSeed.Assert().IsNot(null);
+        }
+
+        [Fact]
+        internal static void Issue_AssertionsContainSeed()
+        {
+            Tools.Asserter.Throws<AssertException>(() => Tools.Asserter.Fail())
+                .Message.Contains($"{Tools.Gen.InitialSeed}").Assert().Is(true);
+        }
+    }
+}

--- a/tests/CreateAndFakeTests/Toolbox/AsserterTool/AssertExceptionTests.cs
+++ b/tests/CreateAndFakeTests/Toolbox/AsserterTool/AssertExceptionTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using CreateAndFake;
+using CreateAndFake.Fluent;
 using CreateAndFake.Toolbox.AsserterTool;
 using CreateAndFakeTests.TestBases;
 using Xunit;
@@ -12,30 +13,35 @@ namespace CreateAndFakeTests.Toolbox.AsserterTool
         [Fact]
         internal static void AssertException_UnknownMessageDefault()
         {
-            Tools.Asserter.Is("Unknown assert failure.", new AssertException(null, null).Message);
+            Tools.Asserter.Is("Unknown assert failure.", new AssertException(null, null, null).Message);
         }
 
         [Theory, RandomData]
-        internal static void AssertException_MessageFormat(string message, string details, string content, Exception ex)
+        internal static void AssertException_MessageFormat(
+            string message, string details, string content, int seed, Exception ex)
         {
-            string nl = Environment.NewLine;
+            new AssertException(message, null, null).Message.Contains(message).Assert().Is(true);
+            new AssertException(message, null, seed).Message.Contains($"{seed}").Assert().Is(true);
 
-            Tools.Asserter.Is(message, new AssertException(message, null).Message);
+            new AssertException(message, details, seed).Message.Contains(message).Assert().Is(true);
+            new AssertException(message, details, seed).Message.Contains(details).Assert().Is(true);
+            new AssertException(message, details, seed).Message.Contains($"{seed}").Assert().Is(true);
+            new AssertException(message, details, seed, ex).Message.Contains(ex.ToString()).Assert().Is(false);
 
-            Tools.Asserter.Is(message + nl + "Details: " + details,
-                new AssertException(message, details).Message);
+            new AssertException(message, null, seed, content).Message.Contains(message).Assert().Is(true);
+            new AssertException(message, null, seed, content).Message.Contains(content).Assert().Is(true);
+            new AssertException(message, null, seed, content).Message.Contains($"{seed}").Assert().Is(true);
 
-            Tools.Asserter.Is(message + nl + "Details: " + details,
-                new AssertException(message, details, ex).Message);
+            new AssertException(message, details, seed, content).Message.Contains(message).Assert().Is(true);
+            new AssertException(message, details, seed, content).Message.Contains(details).Assert().Is(true);
+            new AssertException(message, details, seed, content).Message.Contains(content).Assert().Is(true);
+            new AssertException(message, details, seed, content).Message.Contains($"{seed}").Assert().Is(true);
 
-            Tools.Asserter.Is(message + nl + "Content: " + nl + content,
-                new AssertException(message, null, content).Message);
-
-            Tools.Asserter.Is(message + nl + "Details: " + details + nl + "Content: " + nl + content,
-                new AssertException(message, details, content).Message);
-
-            Tools.Asserter.Is(message + nl + "Details: " + details + nl + "Content: " + nl + content,
-                new AssertException(message, details, content, ex).Message);
+            new AssertException(message, details, seed, content, ex).Message.Contains(message).Assert().Is(true);
+            new AssertException(message, details, seed, content, ex).Message.Contains(details).Assert().Is(true);
+            new AssertException(message, details, seed, content, ex).Message.Contains(content).Assert().Is(true);
+            new AssertException(message, details, seed, content, ex).Message.Contains($"{seed}").Assert().Is(true);
+            new AssertException(message, details, seed, content, ex).Message.Contains(ex.ToString()).Assert().Is(false);
         }
     }
 }

--- a/tests/CreateAndFakeTests/Toolbox/AsserterTool/AsserterTests.cs
+++ b/tests/CreateAndFakeTests/Toolbox/AsserterTool/AsserterTests.cs
@@ -23,7 +23,7 @@ namespace CreateAndFakeTests.Toolbox.AsserterTool
         public AsserterTests()
         {
             _fakeValuer = Tools.Faker.Mock<IValuer>();
-            _testInstance = new Asserter(_fakeValuer.Dummy);
+            _testInstance = new Asserter(Tools.Gen, _fakeValuer.Dummy);
         }
 
         [Fact]

--- a/tests/CreateAndFakeTests/Toolbox/AsserterTool/Fluent/AssertChainerTests.cs
+++ b/tests/CreateAndFakeTests/Toolbox/AsserterTool/Fluent/AssertChainerTests.cs
@@ -22,7 +22,7 @@ namespace CreateAndFakeTests.Toolbox.AsserterTool.Fluent
         [Theory, RandomData]
         internal static void And_PassesBackInstance(object data)
         {
-            Tools.Asserter.Is(data, new AssertChainer<object>(data, Tools.Valuer).And);
+            Tools.Asserter.Is(data, new AssertChainer<object>(data, Tools.Gen, Tools.Valuer).And);
         }
     }
 }


### PR DESCRIPTION
<!--- Follow the contributing guide and code of conduct. --->

## Summary
<!--- Describe the code. --->
Use SeededRandom for defualt randomization.
Provide seed in assertion messages.
Remove Sonar analyzers.

## Fulfills
<!--- Specify which issues the contribution solves. --->

* Closes #81: Use Seeds for Default Randoms
