### PR TITLE
Fix# 99: Faking extension method error.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,9 +12,7 @@
     "cSpell.words": [
         "Callvirt",
         "Chainer",
-        "cobertura",
         "Duplicatable",
-        "finalizer",
         "Ldarg",
         "Ldelem",
         "Ldfld",
@@ -30,9 +28,14 @@
         "Stloc",
         "Xunit",
         "cloner",
+        "cobertura",
         "codacy",
+        "codecov",
         "duplicatables",
         "equatables",
+        "finalizer",
+        "nuget",
+        "nupkg",
         "serializables"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,6 +36,10 @@
         "finalizer",
         "nuget",
         "nupkg",
+        "omnisharp",
         "serializables"
+    ],
+    "cSpell.ignorePaths": [
+        "src/CreateAndFake/Design/Data/"
     ]
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Create & Fake
 
-[![NuGet](https://img.shields.io/nuget/v/CreateAndFake)](https://www.nuget.org/packages/CreateAndFake) [![Build](https://github.com/CreateAndFake/CreateAndFake/workflows/Integration/badge.svg)](../../actions?query=workflow%3AIntegration) [![CodeCov Coverage](https://codecov.io/gh/CreateAndFake/CreateAndFake/branch/master/graph/badge.svg)](https://codecov.io/gh/CreateAndFake/CreateAndFake/branch/master) [![Codacy Grade](https://api.codacy.com/project/badge/Grade/cc753a1417c24f6dba43e2386e89005a)](https://www.codacy.com/app/Werebunny/CreateAndFake?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=CreateAndFake/CreateAndFake&amp;utm_campaign=Badge_Grade)
+[![NuGet](https://img.shields.io/nuget/v/CreateAndFake)](https://www.nuget.org/packages/CreateAndFake) [![Build](https://github.com/CreateAndFake/CreateAndFake/workflows/Integration/badge.svg)](../../actions?query=workflow%3AIntegration) [![CodeCov Coverage](https://codecov.io/gh/CreateAndFake/CreateAndFake/branch/master/graph/badge.svg)](https://codecov.io/gh/CreateAndFake/CreateAndFake/branch/master)
 
 A C# class library that handles mocking, test data generation, and validation. Designed to handle the bulk of test setup quickly and easily so that developers can focus on the behavior to test, making tests easier to develop and maintain:
 
@@ -89,6 +89,5 @@ View the [license](LICENSE.txt) file for more details.
 * [xUnit](https://xunit.github.io/): For running tests.
 * [Coverlet](https://github.com/tonerdo/coverlet) + [ReportGenerator](https://danielpalme.github.io/ReportGenerator/) + [CodeCov](https://codecov.io/): For test coverage.
 * [Bullseye](https://github.com/adamralph/bullseye) + [SimpleExec](https://github.com/adamralph/simple-exec) + [MinVer](https://github.com/adamralph/minver): For project building.
-* [Codacy](https://www.codacy.com/): For code analysis.
 * [GitHub](https://github.com/): For hosting code.
 * [Microsoft](https://visualstudio.microsoft.com/vs/features/net-development/): For C# and editors.

--- a/src/CreateAndFake/Attributes/StubAttribute.cs
+++ b/src/CreateAndFake/Attributes/StubAttribute.cs
@@ -3,6 +3,7 @@ using System;
 namespace CreateAndFake
 {
     /// <summary>Flag to create the object as a stub.</summary>
+    /// <remarks>Stubs are loose fakes with a base default implementation.</remarks>
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = true)]
     public sealed class StubAttribute : Attribute { }
 }

--- a/src/CreateAndFake/Design/Data/NameData.cs
+++ b/src/CreateAndFake/Design/Data/NameData.cs
@@ -102,6 +102,7 @@ namespace CreateAndFake.Design.Data
             // Bu
             "Bud",
             "Buddy",
+            "Bugs",
             "Butters",
             // Bv
             // Bw
@@ -109,6 +110,7 @@ namespace CreateAndFake.Design.Data
             // By
             // Bz
             // Ca
+            "Cander",
             "Carson",
             "Cat",
             "Cathrine",
@@ -125,6 +127,7 @@ namespace CreateAndFake.Design.Data
             "Christine",
             "Christopher",
             // Ci
+            "Cinder",
             "Cindy",
             // Cj
             // Ck
@@ -137,6 +140,7 @@ namespace CreateAndFake.Design.Data
             // Co
             "Cody",
             "Colby",
+            "Conor",
             "Cook",
             // Cp
             // Cq
@@ -197,6 +201,7 @@ namespace CreateAndFake.Design.Data
             // Ds
             // Dt
             // Du
+            "Dustin",
             // Dv
             // Dw
             "Dwayne",
@@ -789,6 +794,7 @@ namespace CreateAndFake.Design.Data
             "Sweeny",
             // Sx
             // Sy
+            "Sylvester",
             // Sz
             // Ta
             "Tae",
@@ -796,6 +802,7 @@ namespace CreateAndFake.Design.Data
             "Tanya",
             "Tasha",
             "Tay",
+            "Taz",
             // Tb
             // Tc
             // Td

--- a/src/CreateAndFake/Toolbox/FakerTool/Fake[T].cs
+++ b/src/CreateAndFake/Toolbox/FakerTool/Fake[T].cs
@@ -118,6 +118,12 @@ namespace CreateAndFake.Toolbox.FakerTool
 
             if (!onlySetter && method.Body is MethodCallExpression methodCall)
             {
+                if (methodCall.Method.IsStatic)
+                {
+                    throw new NotSupportedException(
+                        $"Method '{methodCall.Method.Name}' is static and not an actual member of '{typeof(T).Name}'.");
+                }
+
                 Type[] generics = (methodCall.Method.IsGenericMethod)
                     ? methodCall.Method.GetGenericArguments()
                     : Type.EmptyTypes;

--- a/tests/CreateAndFakeTests/IssueReplication/050-100/Issue099Tests.cs
+++ b/tests/CreateAndFakeTests/IssueReplication/050-100/Issue099Tests.cs
@@ -1,0 +1,36 @@
+using System;
+using CreateAndFake;
+using CreateAndFake.Fluent;
+using CreateAndFake.Toolbox.FakerTool;
+using Xunit;
+
+namespace CreateAndFakeTests.IssueReplication
+{
+    /// <summary>Verifies issue is resolved.</summary>
+    public static class Issue099Tests
+    {
+        public static int ExtendedCall(this ITester sample, object item)
+        {
+            return sample?.GetValue(item) ?? 0;
+        }
+
+        public interface ITester
+        {
+            int GetValue(object item);
+        }
+
+        [Theory, RandomData]
+        internal static void Issue099_FakingThrowsWithExtensionMethod(Fake<ITester> sample, object item, int result)
+        {
+            Tools.Asserter.Throws<NotSupportedException>(
+                () => sample.Setup(f => f.ExtendedCall(item), Behavior.Returns(result)));
+        }
+
+        [Theory, RandomData]
+        internal static void Issue099_FluentPassthroughWithExtensionMethod([Stub] ITester sample, object item, int result)
+        {
+            sample.ExtendedCall(item).SetupReturn(result);
+            sample.ExtendedCall(item).Assert().Is(result);
+        }
+    }
+}


### PR DESCRIPTION
<!--- Follow the contributing guide and code of conduct. --->

## Summary
<!--- Describe the code. --->
When trying to mock extension methods, an easy to understand error is thrown instead of current one.

## Fulfills
<!--- Specify which issues the contribution solves. --->

* Closes #99: Extension Method Error
