### PR TITLE
Fix #106: Better Generic Type Description in Assert Failures.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,21 @@
 // Extension: EditorConfig for VS Code
 {
     "omnisharp.enableEditorConfigSupport": true,
+    "omnisharp.organizeImportsOnFormat": true,
+    "git.enableSmartCommit": true,
     "git.enableCommitSigning": true,
     "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+        "source.sortImports": "explicit",
+        "source.fixAll": "explicit"
+    },
     "editor.rulers": [
         120,
         140
     ],
+    "[csharp]": {
+        "editor.defaultFormatter": "ms-dotnettools.csharp"
+    },
     // Extension: Code Spell Checker
     "cSpell.words": [
         "autobuild",
@@ -23,6 +32,7 @@
         "codeql",
         "comparables",
         "Delegators",
+        "dotnettools",
         "Duplicatable",
         "duplicatables",
         "enumerables",

--- a/src/CreateAndFake/Toolbox/AsserterTool/Fluent/AssertComparableBase.cs
+++ b/src/CreateAndFake/Toolbox/AsserterTool/Fluent/AssertComparableBase.cs
@@ -101,7 +101,7 @@ public abstract class AssertComparableBase<T>(IRandom gen, IValuer valuer, IComp
         }
     }
 
-    /// <summary>Verifies value is matches the <paramref name="math"/>.</summary>
+    /// <summary>Verifies value matches the <paramref name="math"/>.</summary>
     /// <param name="math">Math used to check the value.</param>
     /// <param name="description">Math description to use for error message.</param>
     /// <param name="expected">Value to compare with.</param>

--- a/src/CreateAndFake/Toolbox/AsserterTool/Fluent/AssertObjectBase.cs
+++ b/src/CreateAndFake/Toolbox/AsserterTool/Fluent/AssertObjectBase.cs
@@ -112,7 +112,26 @@ public abstract class AssertObjectBase<T>(IRandom gen, IValuer valuer, object ac
     /// <returns>Found name to use.</returns>
     protected string GetTypeName(object expected)
     {
-        return (expected ?? Actual)?.GetType().Name;
+        return ExpandTypeName((expected ?? Actual)?.GetType());
+    }
+
+    /// <summary>Builds type name with generic argument names.</summary>
+    /// <param name="type">Type to describe.</param>
+    /// <returns>Built name.</returns>
+    private static string ExpandTypeName(Type type)
+    {
+        if (type != null && type.IsGenericType)
+        {
+            return string.Concat(
+                type.Name.AsSpan(0, type.Name.IndexOf('`', StringComparison.InvariantCulture)),
+                "<",
+                string.Join(",", type.GetGenericArguments().Select(ExpandTypeName)),
+                ">");
+        }
+        else
+        {
+            return type?.Name;
+        }
     }
 
     /// <summary>Converts the instance to a chainer.</summary>

--- a/src/CreateAndFake/Toolbox/AsserterTool/Fluent/AssertObjectBase.cs
+++ b/src/CreateAndFake/Toolbox/AsserterTool/Fluent/AssertObjectBase.cs
@@ -125,7 +125,7 @@ public abstract class AssertObjectBase<T>(IRandom gen, IValuer valuer, object ac
         if (type != null && type.IsGenericType)
         {
             return string.Concat(
-                type.Name.AsSpan(0, type.Name.IndexOf('`')),
+                type.Name.Substring(0, type.Name.IndexOf('`')),
                 "<",
                 string.Join(",", type.GetGenericArguments().Select(ExpandTypeName)),
                 ">");

--- a/src/CreateAndFake/Toolbox/AsserterTool/Fluent/AssertObjectBase.cs
+++ b/src/CreateAndFake/Toolbox/AsserterTool/Fluent/AssertObjectBase.cs
@@ -115,6 +115,8 @@ public abstract class AssertObjectBase<T>(IRandom gen, IValuer valuer, object ac
         return ExpandTypeName((expected ?? Actual)?.GetType());
     }
 
+#pragma warning disable CA1307 // Specify StringComparison for clarity
+
     /// <summary>Builds type name with generic argument names.</summary>
     /// <param name="type">Type to describe.</param>
     /// <returns>Built name.</returns>
@@ -123,7 +125,7 @@ public abstract class AssertObjectBase<T>(IRandom gen, IValuer valuer, object ac
         if (type != null && type.IsGenericType)
         {
             return string.Concat(
-                type.Name.AsSpan(0, type.Name.IndexOf('`', StringComparison.InvariantCulture)),
+                type.Name.AsSpan(0, type.Name.IndexOf('`')),
                 "<",
                 string.Join(",", type.GetGenericArguments().Select(ExpandTypeName)),
                 ">");
@@ -133,6 +135,8 @@ public abstract class AssertObjectBase<T>(IRandom gen, IValuer valuer, object ac
             return type?.Name;
         }
     }
+
+#pragma warning restore CA1307 // Specify StringComparison for clarity
 
     /// <summary>Converts the instance to a chainer.</summary>
     /// <returns>The created chainer.</returns>

--- a/src/CreateAndFake/Toolbox/MutatorTool/Mutator.cs
+++ b/src/CreateAndFake/Toolbox/MutatorTool/Mutator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using CreateAndFake.Design;
+using CreateAndFake.Design.Content;
 using CreateAndFake.Toolbox.RandomizerTool;
 using CreateAndFake.Toolbox.ValuerTool;
 
@@ -39,7 +40,18 @@ public sealed class Mutator(IRandomizer randomizer, IValuer valuer, Limiter limi
         {
             _limiter.StallUntil(
                 () => result = _randomizer.Create(type),
-                () => values.All(o => !_valuer.Equals(result, o))).Wait();
+                () =>
+                {
+                    if (values.All(o => !_valuer.Equals(result, o)))
+                    {
+                        return true;
+                    }
+                    else
+                    {
+                        Disposer.Cleanup(result);
+                        return false;
+                    }
+                }).Wait();
         }
         catch (AggregateException e)
         {

--- a/src/CreateAndFake/Toolbox/RandomizerTool/CreateHints/GenericCreateHint.cs
+++ b/src/CreateAndFake/Toolbox/RandomizerTool/CreateHints/GenericCreateHint.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Reflection;
 using CreateAndFake.Design;
+using CreateAndFake.Design.Content;
 using CreateAndFake.Design.Randomization;
 
 namespace CreateAndFake.Toolbox.RandomizerTool.CreateHints;
@@ -69,7 +70,9 @@ public sealed class GenericCreateHint : CreateHint
             while (!constraints.All(c => arg.Inherits(c))
                 && (!newNeeded || arg.GetConstructor(Type.EmptyTypes) != null))
             {
-                arg = randomizer.Create(randomizer.Gen.NextItem(constraints), randomizer.Parent).GetType();
+                object constraint = randomizer.Create(randomizer.Gen.NextItem(constraints), randomizer.Parent);
+                arg = constraint.GetType();
+                Disposer.Cleanup(constraint);
             }
         }).Wait();
 

--- a/src/CreateAndFake/Toolbox/RandomizerTool/Randomizer.cs
+++ b/src/CreateAndFake/Toolbox/RandomizerTool/Randomizer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using CreateAndFake.Design;
+using CreateAndFake.Design.Content;
 using CreateAndFake.Design.Randomization;
 using CreateAndFake.Toolbox.DuplicatorTool;
 using CreateAndFake.Toolbox.FakerTool;
@@ -79,7 +80,18 @@ public sealed class Randomizer : IRandomizer, IDuplicatable
         {
             _limiter.StallUntil(
                 () => result = Create(type, new RandomizerChainer(_faker, _gen, Create)),
-                () => condition?.Invoke(result) ?? true).Wait();
+                () =>
+                {
+                    if (condition?.Invoke(result) ?? true)
+                    {
+                        return true;
+                    }
+                    else
+                    {
+                        Disposer.Cleanup(result);
+                        return false;
+                    }
+                }).Wait();
         }
         catch (AggregateException e)
         {

--- a/src/CreateAndFake/Toolbox/TesterTool/GenericFixer.cs
+++ b/src/CreateAndFake/Toolbox/TesterTool/GenericFixer.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Reflection;
 using CreateAndFake.Design;
+using CreateAndFake.Design.Content;
 using CreateAndFake.Design.Randomization;
 using CreateAndFake.Toolbox.RandomizerTool;
 
@@ -67,7 +68,9 @@ internal sealed class GenericFixer
             while (!constraints.All(c => arg.Inherits(c))
                 && (!newNeeded || arg.GetConstructor(Type.EmptyTypes) != null))
             {
-                arg = _randomizer.Create(_gen.NextItem(constraints)).GetType();
+                object constraint = _randomizer.Create(_gen.NextItem(constraints));
+                arg = constraint.GetType();
+                Disposer.Cleanup(constraint);
             }
         }).Wait();
 

--- a/tests/CreateAndFakeTests/CreateAndFakeTests.csproj
+++ b/tests/CreateAndFakeTests/CreateAndFakeTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OS)'!='Windows_NT'">
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 

--- a/tests/CreateAndFakeTests/IssueReplication/100-150/Issue106Tests.cs
+++ b/tests/CreateAndFakeTests/IssueReplication/100-150/Issue106Tests.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+using CreateAndFake;
+using CreateAndFake.Fluent;
+using CreateAndFake.Toolbox.AsserterTool;
+using Xunit;
+
+namespace CreateAndFakeTests.IssueReplication;
+
+/// <summary>Verifies issue is resolved.</summary>
+public static class Issue106Tests
+{
+    internal sealed class RandomNameContainer<T>
+    {
+        public T Content { get; set; }
+    }
+
+    internal sealed class RandomNameItem
+    {
+        public string Message { get; set; }
+    }
+
+    [Theory, RandomData]
+    internal static void Issue106_AssertIncludesGenericName(RandomNameContainer<RandomNameItem> generic)
+    {
+        generic
+            .Assert(l => l.Assert().Is(generic.CreateVariant()))
+            .Throws<AssertException>()
+            .Message
+            .Assert()
+            .Contains(nameof(RandomNameItem));
+    }
+
+    [Theory, RandomData]
+    internal static void Issue106_AssertIncludesGenericNameCollections(List<Dictionary<string, RandomNameItem>> generic)
+    {
+        generic
+            .Assert(l => l.Assert().Is(generic.CreateVariant()))
+            .Throws<AssertException>()
+            .Message
+            .Assert()
+            .Contains(nameof(RandomNameItem));
+    }
+}

--- a/tests/CreateAndFakeTests/IssueReplication/100-150/Issue106Tests.cs
+++ b/tests/CreateAndFakeTests/IssueReplication/100-150/Issue106Tests.cs
@@ -14,7 +14,7 @@ public static class Issue106Tests
         public T Content { get; set; }
     }
 
-    internal sealed class RandomNameItem
+    public sealed class RandomNameItem
     {
         public string Message { get; set; }
     }


### PR DESCRIPTION
<!--- Follow the contributing guide and code of conduct. --->

<!-- Title Format: Fix #xx, #xx: Small description. --->

## Summary
<!--- Describe the code. --->
Add full names for generic types in assert failure messages.

## Fulfills
<!--- Specify which issues the contribution solves. --->

* Closes #106
